### PR TITLE
Reorg page template

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import os
 import html2text
+import operator
 
 import requests
 from bs4 import BeautifulSoup
@@ -63,6 +64,9 @@ def create_episode(api_episode, base_url, output_dir):
         tags.append(
             {"link": base_url + link.get("href"), "text": link.get_text().strip()}
         )
+
+    # Sort tags by text
+    tags = sorted(tags, key=operator.itemgetter("text"))
 
     hosts = []
     for host in page_soup.find_all("ul", class_="episode-hosts"):

--- a/templates/episode.md.j2
+++ b/templates/episode.md.j2
@@ -25,6 +25,4 @@
 
 ## Tags
 
-{% for tag in tags %}
-* [{{ tag.text }}]({{ tag.link }})
-{%- endfor %}
+{% for tag in tags %}[{{ tag.text }}]({{ tag.link }}){% if not loop.last %}, {% endif %}{% endfor %}

--- a/templates/episode.md.j2
+++ b/templates/episode.md.j2
@@ -9,6 +9,12 @@
 
 {{ blurb }}
 
+## Your hosts
+
+{%- for host in hosts %}
+* [{{ host.name }}]({{ host.link }})
+{%- endfor %}
+
 ## Sponsored by
 
 {{ sponsors }}
@@ -16,12 +22,6 @@
 ## Episode links
 
 {{ links }}
-
-## Your hosts
-
-{% for host in hosts %}
-* [{{ host.name }}]({{ host.link }})
-{%- endfor %}
 
 ## Tags
 

--- a/templates/episode.md.j2
+++ b/templates/episode.md.j2
@@ -1,4 +1,5 @@
 # {{ episode_number_padded }}: {{ title_plain }}
+
 {{ player_embed }}
 
 * Air Date: {{ date_published }}


### PR DESCRIPTION
Shuffle some things around in the page template, so it's in a nicer order

- Add a space between player embed and title (only shows in raw markdown)
- Move hosts above links etc
- Change tags to be comma-separated
- Sort tags into alphabetical order