### PR TITLE
Scrape from RSS feed instead of Fireside JSON API

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ extra:
     office-hours:
       fireside_url: https://www.officehours.hair/
       acronym: OFH
+      use_fireside_json: true
   social:
     - icon: 'fontawesome/brands/twitter'
       link: 'https://twitter.com/jupiterbroadcasting'


### PR DESCRIPTION
This PR adds new functionality to scrape data from a show's RSS feed rather than the Fireside JSON API. This fixes scraping of LUP, and also (partially) reduces reliance on fireside.

Through the use of a new flag in the config, `use_fireside_json`, the previous behavior can be used instead. I've kept this functionality for Office Hours as the current feed does not have correct duration tags. Once that is fixed, it too could be migrated.