### PR TITLE
Backfill LINUX Unplugged

### DIFF
--- a/docs/coder-radio/2022/episode-gamer.md
+++ b/docs/coder-radio/2022/episode-gamer.md
@@ -1,0 +1,33 @@
+# CR gamer: Gaming with Perspective - Test Show
+
+<iframe src="https://player.fireside.fm/v2/MLf2ZzhC+PUB63yNn?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2022-12-23
+* Duration: {hours} hours {minutes} mins {seconds} secs
+
+## About this episode
+
+Mike and Chris spend a little time chatting about one of their loves in life, great games. It's a test pilot episode for a possible new show, and we'd like your feedback. Consider it a holiday treat for the Coder fans out there.
+
+## Your hosts
+* [Chris Fisher](https://coder.show/hosts/chrislas)
+* [Michael Dominick](https://coder.show/hosts/michael)
+
+## Sponsored by
+
+  * [Network Membership Holiday Discount](https://jupitersignal.memberful.com/checkout?plan=74364&coupon=2024): [Support the entire network, and get access to every member's special feed for every show on the network. Sign up now and save $3/m FOREVER!](https://jupitersignal.memberful.com/checkout?plan=74364&coupon=2024) Promo Code: 2024
+
+
+
+## Episode links
+
+  * [Super Mario All-Stars - Full Game Walkthrough - YouTube](https://www.youtube.com/watch?v=SNl6WJygciw "Super Mario All-Stars - Full Game Walkthrough - YouTube")
+  * [Dash, Inventor Extraordinaire](https://fabtcg.com/heroes/dash/ "Dash, Inventor Extraordinaire")
+  * [Dark Castle (1986) - Original Macintosh Version!](https://www.youtube.com/watch?v=KCkbp4wurW0 "Dark Castle \(1986\) - Original Macintosh Version!")
+  * [GRUUL Mid // Pioneer deck list mtg // Moxfield — An mtg deck builder site for Magic: the Gathering®](https://www.moxfield.com/decks/zio9pL7rAUec_3SamQEnrA "GRUUL Mid // Pioneer deck list mtg // Moxfield — An mtg deck builder site for Magic: the Gathering®")
+
+
+
+## Tags
+
+[classic games](https://coder.show/tags/classic%20games), [dark castle](https://coder.show/tags/dark%20castle), [family gaming](https://coder.show/tags/family%20gaming), [flesh and blood](https://coder.show/tags/flesh%20and%20blood), [gameboy](https://coder.show/tags/gameboy), [gamer radio](https://coder.show/tags/gamer%20radio), [gaming culture](https://coder.show/tags/gaming%20culture), [genisis](https://coder.show/tags/genisis), [magic the gathering](https://coder.show/tags/magic%20the%20gathering), [marvel midnight sun](https://coder.show/tags/marvel%20midnight%20sun), [nintendo](https://coder.show/tags/nintendo), [pokemon](https://coder.show/tags/pokemon), [saga](https://coder.show/tags/saga)

--- a/docs/coder-radio/2024/episode-hurricanehelene.md
+++ b/docs/coder-radio/2024/episode-hurricanehelene.md
@@ -1,0 +1,31 @@
+# CR hurricanehelene: A Coder PSA
+
+<iframe src="https://player.fireside.fm/v2/MLf2ZzhC+wPM2yivv?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-09-24
+* Duration: {hours} hours {minutes} mins {seconds} secs
+
+## About this episode
+
+A quick update from Chris on where the show is at this week, and what to watch out for next week!
+
+## Your hosts
+* [Chris Fisher](https://coder.show/hosts/chrislas)
+* [Michael Dominick](https://coder.show/hosts/michael)
+
+## Sponsored by
+
+  * [Coder QA](https://jupitersignal.memberful.com/checkout?plan=53334&coupon=jarjar): [Take $2 a month off for the lifetime of your membership and contribute to our show directly](https://jupitersignal.memberful.com/checkout?plan=53334&coupon=jarjar) Promo Code: jarjar
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike") — Strike is a lightning-powered app that lets you quickly and cheaply grab sats in over 100 countries. Easily integrates with Fountain.fm. Setup your Strike account, and you have one of the world's best ways to buy sats.
+  * [🇨🇦 Bitcoin Well](https://bitcoinwell.com/ "🇨🇦 Bitcoin Well") — Enable your independence with the fastest and safest way to buy bitcoin in Canada and the USA. Focused on Bitcoin excellence, enabling true financial independence 🥇
+  * [📻 Boost with Fountain.FM](https://fountain.fm/ "📻 Boost with Fountain.FM") — Boost from Fountain.FM's website and keep your current Podcast app. Or kick the tires on the Podcasting 2.0 revolution and try out Fountain.FM the app! 🚀
+
+
+
+## Tags
+

--- a/docs/linux-unplugged/2024/episode-553.md
+++ b/docs/linux-unplugged/2024/episode-553.md
@@ -1,0 +1,55 @@
+# LUP 553: Portably Predictable Productivity
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+6wgk3Yvm?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-03-10
+* Duration: 81 mins 23 secs
+
+## About this episode
+
+We each bring surprise topics, a mix of hardware and software, as we prepare to hit the road for NixCon and SCaLE.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [FlakeHub.com](https://determinate.systems/unplugged): [FlakeHub.com is the all-in-one platform for secure, compliant, and transformative Nix development. Bring Nix to work the way you always wanted with FlakeHub.com. Register for the private beta and get a secure, compliance-friendly Nix and all the support you need.](https://determinate.systems/unplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn’t trusted and secure, it can’t log into your cloud apps.](https://kolide.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged on Fountain.FM")
+  * [NVIDIA SHIELD Portable](https://www.amazon.com/NVIDIA-SHIELD-Portable-pc/dp/B00E3667XQ?th=1 "NVIDIA SHIELD Portable") — Stream PC games, play android games, run apps, movies, music, and more.
+  * [Fountain](http://fountain.fm/ "Fountain") — Podcasts powered by community 
+  * [🍔 Lunch at SCaLE 🍇, Sat, Mar 16, 2024, 1:30 PM](https://www.meetup.com/jupiterbroadcasting/events/298780542 "🍔 Lunch at SCaLE 🍇, Sat, Mar 16, 2024, 1:30 PM")
+  * [Yard House Menu](https://www.yardhouse.com/menu/starters/apps?setRestaurant=8307&cmpid=br:yh_ag:ie_ch:dry_ca:YHGMB_sn:gmb_gt:pasadena-ca-8307_pl:menu_rd:1006 "Yard House Menu")
+  * [Super Productivity](https://super-productivity.com/ "Super Productivity") — Super Productivity is an advanced todo list app with integrated Timeboxing and time tracking capabilities. It also comes with integrations for Jira, Gitlab, GitHub and Open Project. 
+  * [Super Productivity on GitHub](https://github.com/johannesjo/super-productivity "Super Productivity on GitHub")
+  * [Super Productivity Demo](https://app.super-productivity.com/ "Super Productivity Demo")
+  * [fort-nix/nix-bitcoin](https://github.com/fort-nix/nix-bitcoin "fort-nix/nix-bitcoin") — A collection of Nix packages and NixOS modules for easily installing full-featured Bitcoin nodes with an emphasis on security. 
+  * [Podcastindex-org/helipad](https://github.com/Podcastindex-org/helipad "Podcastindex-org/helipad") — This is a simple lnd poller and web front-end to see and read boosts and boostagrams. 
+  * [Added settings page and webhook settings by ericpp · Helipad PR #79](https://github.com/Podcastindex-org/helipad/pull/79 "Added settings page and webhook settings by ericpp · Helipad PR #79")
+  * [noblepayne/helipad-flake](https://github.com/noblepayne/helipad-flake "noblepayne/helipad-flake") — Basic nix flake for helipad.
+  * [R36S Retro Handheld](https://www.aliexpress.us/item/3256805966676624.html "R36S Retro Handheld") — Handheld Video Game Console, Linux System, 3.5 Inch IPS Screen, 64GB 
+  * [Amazon.com: Retro Handheld Game Console](https://www.amazon.com/Handheld-Console-Source-System-Portable/dp/B0CMXHV48N "Amazon.com: Retro Handheld Game Console")
+  * [ArkOS Emulators and Ports information](https://github.com/christianhaitian/arkos/wiki/ArkOS-Emulators-and-Ports-information "ArkOS Emulators and Ports information")
+  * [ArkOS Wiki](https://github.com/christianhaitian/arkos/wiki "ArkOS Wiki")
+  * [nixos-bsd/nixbsd](https://github.com/nixos-bsd/nixbsd "nixos-bsd/nixbsd") — An unofficial NixOS fork with a FreeBSD kernel.
+  * [Akylas/OSS-DocumentScanner](https://github.com/Akylas/OSS-DocumentScanner "Akylas/OSS-DocumentScanner") — Android document scanning app. 
+  * [upscayl](https://github.com/upscayl/upscayl "upscayl") — Free and Open Source AI Image Upscaler for Linux, MacOS and Windows built with Linux-First philosophy.
+  * [Pick: AnyType](https://anytype.io/ "Pick: AnyType") — The everything app for those who celebrate trust & autonomy. 
+  * [Unplugged Core Membership](https://unpluggedcore.com/ "Unplugged Core Membership")
+  * [Jupiter Signal PROMO 2024 - $3 off a month forever](https://jupitersignal.memberful.com/checkout?plan=74364&coupon=2024 "Jupiter Signal PROMO 2024 - $3 off a month forever")
+
+
+
+## Tags
+
+[android auto](https://linuxunplugged.com/tags/android%20auto), [anytype](https://linuxunplugged.com/tags/anytype), [arkos](https://linuxunplugged.com/tags/arkos), [audio infrastructure](https://linuxunplugged.com/tags/audio%20infrastructure), [borg backups](https://linuxunplugged.com/tags/borg%20backups), [document scanner apps](https://linuxunplugged.com/tags/document%20scanner%20apps), [fountain.fm](https://linuxunplugged.com/tags/fountain.fm), [game emulator](https://linuxunplugged.com/tags/game%20emulator), [genius scan](https://linuxunplugged.com/tags/genius%20scan), [glove80 ergonomic keyboard](https://linuxunplugged.com/tags/glove80%20ergonomic%20keyboard), [grapheneos](https://linuxunplugged.com/tags/grapheneos), [helipad](https://linuxunplugged.com/tags/helipad), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [local ai models](https://linuxunplugged.com/tags/local%20ai%20models), [local-first note app](https://linuxunplugged.com/tags/local-first%20note%20app), [nix package manager nvidia shield portable](https://linuxunplugged.com/tags/nix%20package%20manager%20nvidia%20shield%20portable), [nix-bitcoin](https://linuxunplugged.com/tags/nix-bitcoin), [nixbsd](https://linuxunplugged.com/tags/nixbsd), [nixcon](https://linuxunplugged.com/tags/nixcon), [owntracks](https://linuxunplugged.com/tags/owntracks), [paperless-ngx](https://linuxunplugged.com/tags/paperless-ngx), [podcasting 2.0](https://linuxunplugged.com/tags/podcasting%202.0), [retro handheld game console](https://linuxunplugged.com/tags/retro%20handheld%20game%20console), [super-productivity](https://linuxunplugged.com/tags/super-productivity), [todo app](https://linuxunplugged.com/tags/todo%20app), [upscayl image upscaler](https://linuxunplugged.com/tags/upscayl%20image%20upscaler)

--- a/docs/linux-unplugged/2024/episode-554.md
+++ b/docs/linux-unplugged/2024/episode-554.md
@@ -1,0 +1,56 @@
+# LUP 554: SCaLEing Nix
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+6NX4cWo1?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-03-17
+* Duration: 89 mins 10 secs
+
+## About this episode
+
+We're on the ground live at NixCon and SCaLE. We catch up with old friends, and discover how Nix is devouring the Linux world one function at a time.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+* [Daphne Muller](https://linuxunplugged.com/guests/daphne-muller)
+* [Eelco Dolstra](https://linuxunplugged.com/guests/eelco-dolstra)
+* [Jos Poortvliet](https://linuxunplugged.com/guests/jos-poortvliet)
+* [Listener Jeff](https://linuxunplugged.com/guests/jeff)
+* [Martin Wimpress](https://linuxunplugged.com/guests/martinwimpress)
+* [Noah Chelliah](https://linuxunplugged.com/guests/kernellinux)
+* [Rok Garbas](https://linuxunplugged.com/guests/rokgarbas)
+* [Ron Efroni](https://linuxunplugged.com/guests/ron-efroni)
+* [Ross Turk](https://linuxunplugged.com/guests/ross-turk)
+* [Ryan Lahfa](https://linuxunplugged.com/guests/ryanlahfa)
+* [Zach Mitchell](https://linuxunplugged.com/guests/zach-mitchell)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [FlakeHub.com](https://determinate.systems/unplugged): [FlakeHub.com is the all-in-one platform for secure, compliant, and transformative Nix development. Bring Nix to work the way you always wanted with FlakeHub.com. Register for the private beta and get a secure, compliance-friendly Nix and all the support you need.](https://determinate.systems/unplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn’t trusted and secure, it can’t log into your cloud apps.](https://kolide.com/unplugged)
+
+
+
+## Episode links
+
+  * [nix-community/lanzaboote](https://github.com/nix-community/lanzaboote "nix-community/lanzaboote") — Secure Boot for NixOS
+  * [Eelco Dolstra’s PhD Thesis](https://edolstra.github.io/pubs/phd-thesis.pdf "Eelco Dolstra’s PhD Thesis") — The Purely Functional Software Deployment Model
+  * [Docker and Nix (DockerCon 2023) [YouTube]](https://www.youtube.com/watch?v=l17oRkhgqHE "Docker and Nix \(DockerCon 2023\) \[YouTube\]")
+  * [Flox](https://flox.dev/ "Flox") — Create development environments with all the dependencies you need and easily share them with colleagues. Work consistently across the entire software lifecycle.
+  * [flox on GitHub](https://github.com/flox/flox "flox on GitHub") — Developer environments you can take with you.
+  * [Gsettings - Monitor All System Settings Change](https://discourse.gnome.org/t/gsettings-monitor-all-system-settings-change/3699 "Gsettings - Monitor All System Settings Change")
+  * [dconf Reference Manual](https://developer-old.gnome.org/dconf/unstable/dconf-tool.html "dconf Reference Manual")
+  * [foss-north](https://foss-north.se/ "foss-north") — foss-north is a free / open source conference covering both software and hardware from the technical perspective. We provide a meeting place for the Nordic foss communities and will bring together great speakers with great audiences.
+  * [An Open Letter from NixOS Users Against MIC Sponsorship](https://nixos-users-against-mic-sponsorship.github.io/ "An Open Letter from NixOS Users Against MIC Sponsorship") — Several members of the community are uneasy with the current happenings around the North American Gathering aimed at NixOS Users and its community (also known as NixCon [sic] NA).
+  * [pjones/plasma-manager](https://github.com/pjones/plasma-manager "pjones/plasma-manager") — Manage KDE Plasma with Home Manager.
+  * [Bastard Keyboards](https://bastardkb.com/ "Bastard Keyboards") — Custom-designed split keyboards with feature-full firmware.
+  * [Bastardkb on GitHub](https://github.com/Bastardkb/ "Bastardkb on GitHub")
+  * [Pick: nix-starter-configs](https://github.com/Misterio77/nix-starter-configs "Pick: nix-starter-configs") — Simple and documented config templates to help you get started with NixOS + home-manager + flakes.
+
+
+
+## Tags
+
+[ai](https://linuxunplugged.com/tags/ai), [alaska](https://linuxunplugged.com/tags/alaska), [california](https://linuxunplugged.com/tags/california), [castamatic](https://linuxunplugged.com/tags/castamatic), [community](https://linuxunplugged.com/tags/community), [daphne muller](https://linuxunplugged.com/tags/daphne%20muller), [dconf](https://linuxunplugged.com/tags/dconf), [determinate systems](https://linuxunplugged.com/tags/determinate%20systems), [docker](https://linuxunplugged.com/tags/docker), [eelco dolstra](https://linuxunplugged.com/tags/eelco%20dolstra), [flox](https://linuxunplugged.com/tags/flox), [fossnorth](https://linuxunplugged.com/tags/fossnorth), [fountain](https://linuxunplugged.com/tags/fountain), [germany](https://linuxunplugged.com/tags/germany), [gnome](https://linuxunplugged.com/tags/gnome), [gsettings](https://linuxunplugged.com/tags/gsettings), [hydra](https://linuxunplugged.com/tags/hydra), [jim klark](https://linuxunplugged.com/tags/jim%20klark), [jos poortvliet](https://linuxunplugged.com/tags/jos%20poortvliet), [lanzaboote](https://linuxunplugged.com/tags/lanzaboote), [martin wimpress](https://linuxunplugged.com/tags/martin%20wimpress), [ml](https://linuxunplugged.com/tags/ml), [nextcloud](https://linuxunplugged.com/tags/nextcloud), [nix](https://linuxunplugged.com/tags/nix), [nix-starter-configs](https://linuxunplugged.com/tags/nix-starter-configs), [nixcon](https://linuxunplugged.com/tags/nixcon), [nixcon na](https://linuxunplugged.com/tags/nixcon%20na), [nixos](https://linuxunplugged.com/tags/nixos), [nixos desktop](https://linuxunplugged.com/tags/nixos%20desktop), [nixpkgs](https://linuxunplugged.com/tags/nixpkgs), [nostr](https://linuxunplugged.com/tags/nostr), [podcast addict](https://linuxunplugged.com/tags/podcast%20addict), [podcast guru](https://linuxunplugged.com/tags/podcast%20guru), [podverse](https://linuxunplugged.com/tags/podverse), [ross turk](https://linuxunplugged.com/tags/ross%20turk), [ryan lahfa](https://linuxunplugged.com/tags/ryan%20lahfa), [scale](https://linuxunplugged.com/tags/scale), [scale 21x](https://linuxunplugged.com/tags/scale%2021x), [secure boot](https://linuxunplugged.com/tags/secure%20boot), [self-hosted ai](https://linuxunplugged.com/tags/self-hosted%20ai), [southern california linux expo](https://linuxunplugged.com/tags/southern%20california%20linux%20expo), [tom bereknyei](https://linuxunplugged.com/tags/tom%20bereknyei), [ubucon](https://linuxunplugged.com/tags/ubucon), [wimpy](https://linuxunplugged.com/tags/wimpy), [yuba city](https://linuxunplugged.com/tags/yuba%20city), [zach mitchell](https://linuxunplugged.com/tags/zach%20mitchell)

--- a/docs/linux-unplugged/2024/episode-555.md
+++ b/docs/linux-unplugged/2024/episode-555.md
@@ -1,0 +1,56 @@
+# LUP 555: Glide like a Goose, Honk like a Moose
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+WjGLzD1y?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-03-24
+* Duration: 75 mins 41 secs
+
+## About this episode
+
+We test the Linux-first, all-AMD Sirius 16 laptop, discuss the new Hyprland release, and share a few stories from our recent trip.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [FlakeHub.com](https://determinate.systems/unplugged): [FlakeHub.com is the all-in-one platform for secure, compliant, and transformative Nix development. Bring Nix to work the way you always wanted with FlakeHub.com. Register for the private beta and get a secure, compliance-friendly Nix and all the support you need.](https://determinate.systems/unplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn’t trusted and secure, it can’t log into your cloud apps.](https://kolide.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged on Fountain.FM")
+  * [Introducing GNOME 46](https://release.gnome.org/46/ "Introducing GNOME 46") — GNOME 46 is code-named “Kathmandu”, in recognition of the amazing work done by the organizers of GNOME.Asia 2023.
+  * [S.O.D.A Machine (Shell On Demand Appliance)](https://forum.defcon.org/node/246908 "S.O.D.A Machine \(Shell On Demand Appliance\)") — A fusion of hardware, software, art, and hacking, all encapsulated in a project derived from recycled materials.
+  * [LINUX Unplugged on Fountain](https://fountain.fm/show/dWiuBeqpDSM86AwXRXov "LINUX Unplugged on Fountain")
+  * [Nostr Protocol Docs](https://nostr.com/the-protocol "Nostr Protocol Docs") — Details on how the Nostr Protocol works and why. 
+  * [Hyprland](https://hyprland.org/ "Hyprland") — Hyprland is a highly customizable dynamic tiling Wayland compositor that doesn't sacrifice on its looks.
+  * [Hyprland Wayland Compositor Celebrates Two Years With A New Release](https://www.phoronix.com/news/Hyprland-0.37 "Hyprland Wayland Compositor Celebrates Two Years With A New Release")
+  * [hyprland 0.37.1 nixpkgs PR](https://github.com/NixOS/nixpkgs/pull/296446 "hyprland 0.37.1 nixpkgs PR")
+  * [Hyprland Release v0.37.1 on GitHub](https://github.com/hyprwm/Hyprland/releases/tag/v0.37.1 "Hyprland Release v0.37.1 on GitHub")
+  * [Hyprland Release v0.37.0 on GitHub](https://github.com/hyprwm/Hyprland/releases/tag/v0.37.0 "Hyprland Release v0.37.0 on GitHub")
+  * [Installing NixOS with Hyprland! - by Josiah - Tech Prose](https://josiahalenbrown.substack.com/p/installing-nixos-with-hyprland "Installing NixOS with Hyprland! - by Josiah - Tech Prose") — In this guide, we will install a minimal version of NixOS with the Wayland compositor Hyprland and Waybar.
+  * [TUXEDO Sirius 16 - Gen1](https://www.tuxedocomputers.com/en/TUXEDO-Sirius-16-Gen1 "TUXEDO Sirius 16 - Gen1") — First all-AMD Linux gaming laptop with highly efficient Ryzen 7 7840HS and fast Radeon RX 7600M XT graphics.
+  * [All AMD: TUXEDO Sirius 16 - Gen1 on YouTube](https://www.youtube.com/watch?v=YVfaXePBTuI "All AMD: TUXEDO Sirius 16 - Gen1 on YouTube")
+  * [Background information on the new keyboard lighting control - TUXEDO Computers](https://www.tuxedocomputers.com/en/Dev-Thoughts-Background-information-on-the-new-keyboard-lighting-control.tuxedo "Background information on the new keyboard lighting control - TUXEDO Computers")
+  * [Texas Linux Festival 2024](https://2024.texaslinuxfest.org/ "Texas Linux Festival 2024") — April 12-13, 2024 in Austin, Texas.
+  * [Scinary Cybersecurity](http://scinary.com/ "Scinary Cybersecurity") — Your On-Demand Cybersecurity Firm.
+  * [nixos-mailserver](https://gitlab.com/simple-nixos-mailserver/nixos-mailserver "nixos-mailserver") — A complete and Simple Nixos Mailserver.
+  * [List of all NixOS Services](https://mynixos.com/nixpkgs/options/services "List of all NixOS Services")
+  * [jus10mar10's NixOS Config](http://github.com/justinmartin/Snowfall-Flake "jus10mar10's NixOS Config")
+  * [dockur/windows](https://github.com/dockur/windows "dockur/windows") — Windows in a Docker container. 
+  * [Unplugged Core Membership](https://unpluggedcore.com/ "Unplugged Core Membership")
+  * [Pick: ATLauncher](https://flathub.org/apps/com.atlauncher.ATLauncher "Pick: ATLauncher") — A launcher for Minecraft which integrates multiple different modpacks to allow you to download and install modpacks easily and quickly.
+  * [Pick: Dissent](https://flathub.org/apps/so.libdb.dissent "Pick: Dissent") — Unofficial GTK4 Discord client in Go, use at your own risk!
+
+
+
+## Tags
+
+[amd](https://linuxunplugged.com/tags/amd), [animations](https://linuxunplugged.com/tags/animations), [compositor](https://linuxunplugged.com/tags/compositor), [desktop flake](https://linuxunplugged.com/tags/desktop%20flake), [enhanced file operations](https://linuxunplugged.com/tags/enhanced%20file%20operations), [files search everywhere](https://linuxunplugged.com/tags/files%20search%20everywhere), [fountain](https://linuxunplugged.com/tags/fountain), [gaming laptop](https://linuxunplugged.com/tags/gaming%20laptop), [gnome 46](https://linuxunplugged.com/tags/gnome%2046), [hyprland](https://linuxunplugged.com/tags/hyprland), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kathmandu](https://linuxunplugged.com/tags/kathmandu), [linux gaming notebook](https://linuxunplugged.com/tags/linux%20gaming%20notebook), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [nix community](https://linuxunplugged.com/tags/nix%20community), [nix flakes](https://linuxunplugged.com/tags/nix%20flakes), [nixcon na](https://linuxunplugged.com/tags/nixcon%20na), [nixos](https://linuxunplugged.com/tags/nixos), [nixos-mailserver](https://linuxunplugged.com/tags/nixos-mailserver), [nostr protocol](https://linuxunplugged.com/tags/nostr%20protocol), [podverse](https://linuxunplugged.com/tags/podverse), [rdp](https://linuxunplugged.com/tags/rdp), [remote desktop protocol](https://linuxunplugged.com/tags/remote%20desktop%20protocol), [scale](https://linuxunplugged.com/tags/scale), [sirius 16](https://linuxunplugged.com/tags/sirius%2016), [sirius 16 gen1](https://linuxunplugged.com/tags/sirius%2016%20gen1), [stickers](https://linuxunplugged.com/tags/stickers), [stirling pdf](https://linuxunplugged.com/tags/stirling%20pdf), [taskwarrior](https://linuxunplugged.com/tags/taskwarrior), [texas linux fest](https://linuxunplugged.com/tags/texas%20linux%20fest), [texas linux festival](https://linuxunplugged.com/tags/texas%20linux%20festival), [tuxedo computers](https://linuxunplugged.com/tags/tuxedo%20computers), [ubuntu mate](https://linuxunplugged.com/tags/ubuntu%20mate), [vr on linux](https://linuxunplugged.com/tags/vr%20on%20linux), [wayland](https://linuxunplugged.com/tags/wayland), [windows in docker](https://linuxunplugged.com/tags/windows%20in%20docker), [windows vm](https://linuxunplugged.com/tags/windows%20vm)

--- a/docs/linux-unplugged/2024/episode-556.md
+++ b/docs/linux-unplugged/2024/episode-556.md
@@ -1,0 +1,60 @@
+# LUP 556: The xz Backdoor Exposed 🚨
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+RJk2qe3U?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-03-31
+* Duration: 70 mins 3 secs
+
+## About this episode
+
+We're breaking down the attack: how it works, how it was hidden, and why time was running out for the attacker.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://kolide.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged on Fountain.FM")
+  * [oss-security mailing list](https://www.openwall.com/lists/oss-security/2024/03/29/4 "oss-security mailing list") — Backdoor in upstream xz/liblzma leading to ssh server compromise.
+  * [Fedora Announcement](https://www.redhat.com/en/blog/urgent-security-alert-fedora-41-and-rawhide-users "Fedora Announcement")
+  * [Debian Announcement](https://security-tracker.debian.org/tracker/CVE-2024-3094 "Debian Announcement")
+  * [Ubuntu Announcement](https://discourse.ubuntu.com/t/xz-liblzma-security-update/43714 "Ubuntu Announcement")
+  * [Kali Linux Announcement](https://www.kali.org/blog/about-the-xz-backdoor/ "Kali Linux Announcement")
+  * [Arch Linux Announcement](https://archlinux.org/news/the-xz-package-has-been-backdoored/ "Arch Linux Announcement")
+  * [Gentoo Announcement](https://bugs.gentoo.org/928134 "Gentoo Announcement")
+  * [openSUSE Tumbleweeed Announcement](https://news.opensuse.org/2024/03/29/xz-backdoor/ "openSUSE Tumbleweeed Announcement")
+  * [NixOS Unstable Discussion](https://discourse.nixos.org/t/cve-2024-3094-malicious-code-in-xz-5-6-0-and-5-6-1-tarballs/42405 "NixOS Unstable Discussion")
+  * [Why does it take two weeks for NixOS to replace xz?](https://discourse.nixos.org/t/cve-2024-3094-malicious-code-in-xz-5-6-0-and-5-6-1-tarballs/42405/5 "Why does it take two weeks for NixOS to replace xz?")
+  * [Andres Freund on Mastodon](https://mastodon.social/@AndresFreundTec/112180406142695845 "Andres Freund on Mastodon") — I was doing some micro-benchmarking at the time, needed to quiesce the system to reduce noise. Saw sshd processes were using a surprising amount of CPU, despite immediately failing because of wrong usernames etc....
+  * [rwmj on Hacker News](https://news.ycombinator.com/item?id=39865810 "rwmj on Hacker News") — Very annoying - the apparent author of the backdoor was in communication with me over several weeks trying to get xz 5.6.x added to Fedora 40 & 41 because of its "great new features"
+  * [A Microcosm of the interactions in Open Source projects](https://robmensching.com/blog/posts/2024/03/30/a-microcosm-of-the-interactions-in-open-source-projects/ "A Microcosm of the interactions in Open Source projects") — Make no mistake. This is the way it works. It needs to change.
+  * [Devuan GNU/Linux on X](https://twitter.com/devuanorg/status/1774029432979653069?t=ASJqAbm5fVHDKeq7CLKqjw "Devuan GNU/Linux on X") — Devuan is not affected by the latest vulnerability caused by systemd.
+  * [systemd PR: Dynamically load compression libraries](https://github.com/systemd/systemd/pull/31550#issuecomment-1972737923 "systemd PR: Dynamically load compression libraries")
+  * [Matteo Croce on X](https://twitter.com/teknoraver85/status/1774452847188312163 "Matteo Croce on X") — I'm the author of such PR. While I absolutely didn't know that libxz had a backdoor, I really think that libraries should be loaded on-demand when rarely used, hence my change :)
+  * [Ryan C. Gordon on X](https://twitter.com/icculus/status/1774310925035524333 "Ryan C. Gordon on X") — This is probably how the xz thing happened, right?
+  * [Jan Wildeboer on the Fediverse](https://social.wildeboer.net/@jwildeboer/112184074379919145 "Jan Wildeboer on the Fediverse") — Again the FOSS world has proven to be vigilant and proactive in finding bugs and backdoors, IMHO.
+  * [Unplugged Core Membership](https://unpluggedcore.com/ "Unplugged Core Membership")
+  * [TXLF is coming up! ](https://2024.texaslinuxfest.org/ "TXLF is coming up! ") — April 12 - 13 in Austin, Texas.
+  * [LFNW coming up!](https://linuxfestnorthwest.org/ "LFNW coming up!") — April 26 - 28
+  * [Mobile Game Ads Are Boosting Podcast Follower Counts](https://www.bloomberg.com/news/newsletters/2024-03-28/mobile-game-ads-are-boosting-podcast-follower-counts "Mobile Game Ads Are Boosting Podcast Follower Counts") — Wondery, iHeart and Lemonada Media are all using a non-public product from MowPod - which gives extra lives and game credits to gamers if they follow shows on Apple Podcasts from game apps.
+  * [MowPod's podcast promotion tools: tales from the bar](https://podnews.net/article/mowpod-promotion "MowPod's podcast promotion tools: tales from the bar")
+  * [fortydeux's NixOS Configs](https://github.com/fortydeux/Fortydeux-NixOS-System-Flake/ "fortydeux's NixOS Configs")
+  * [Prism Launcher](https://prismlauncher.org/ "Prism Launcher") — An Open Source Minecraft launcher with the ability to manage multiple instances, accounts and mods.
+  * [World Backup Day — March 31st](https://www.worldbackupday.com/en/ "World Backup Day — March 31st") — One small accident or failure could destroy all the important stuff you care about.
+  * [Updating Our Fiddly Bits | LINUX Unplugged 494](https://www.jupiterbroadcasting.com/show/linux-unplugged/494/ "Updating Our Fiddly Bits | LINUX Unplugged 494")
+
+
+
+## Tags
+
+[alpine](https://linuxunplugged.com/tags/alpine), [arch linux](https://linuxunplugged.com/tags/arch%20linux), [backdoor](https://linuxunplugged.com/tags/backdoor), [burnout](https://linuxunplugged.com/tags/burnout), [compression libraries](https://linuxunplugged.com/tags/compression%20libraries), [debian](https://linuxunplugged.com/tags/debian), [fedora](https://linuxunplugged.com/tags/fedora), [gentoo](https://linuxunplugged.com/tags/gentoo), [humint](https://linuxunplugged.com/tags/humint), [jia tan](https://linuxunplugged.com/tags/jia%20tan), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kali linux](https://linuxunplugged.com/tags/kali%20linux), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [nixos](https://linuxunplugged.com/tags/nixos), [open source](https://linuxunplugged.com/tags/open%20source), [openssh](https://linuxunplugged.com/tags/openssh), [opensuse](https://linuxunplugged.com/tags/opensuse), [remote code execution](https://linuxunplugged.com/tags/remote%20code%20execution), [systemd](https://linuxunplugged.com/tags/systemd), [transparency](https://linuxunplugged.com/tags/transparency), [trust model](https://linuxunplugged.com/tags/trust%20model), [ubuntu](https://linuxunplugged.com/tags/ubuntu), [xz](https://linuxunplugged.com/tags/xz)

--- a/docs/linux-unplugged/2024/episode-557.md
+++ b/docs/linux-unplugged/2024/episode-557.md
@@ -1,0 +1,50 @@
+# LUP 557: Crouching kexec, Hidden Linux
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+6GvqwQZz?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-04-07
+* Duration: 59 mins 17 secs
+
+## About this episode
+
+We're building a completely hidden Linux OS inside an existing system—with no trace left behind.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://kolide.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike") — The global money app for fast, safe payments and bitcoin. Get sats easy.
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged on Fountain.FM") — Grab the Fountain app and listen live, boost along, and more. 
+  * [Shufflecake](https://shufflecake.net/ "Shufflecake") — Plausible deniability for multiple hidden filesystems on Linux
+  * [System76 and Jupiter Broadcasting Epic Parking Lot BBQ, Sat, Apr 27, 2024, 4:30 PM | Meetup](https://www.meetup.com/system76-community/events/299957317 "System76 and Jupiter Broadcasting Epic Parking Lot BBQ, Sat, Apr 27, 2024, 4:30 PM | Meetup")
+  * [Jupiter Extras: Nostr Workshop](https://extras.show/90 "Jupiter Extras: Nostr Workshop") — Our Nostr workshop. We'll help you get your Nostr identity and answer any questions. 
+  * [24.05 Call for Release Manager &amp; Editor - NixOS](https://discourse.nixos.org/t/24-05-call-for-release-manager-editor/42195 "24.05 Call for Release Manager & Editor  - NixOS") — Both roles are fulfilled in tandem, meaning you get paired with an experienced partner, who already filled the role during the previous release.
+  * [HiddenVM — Use any desktop OS without leaving a trace.](https://github.com/aforensics/HiddenVM/ "HiddenVM — Use any desktop OS without leaving a trace.") — HiddenVM is a simple, one-click, free and open-source Linux application that allows you to run Oracle's open-source VirtualBox software on the Tails operating system.
+  * [Tails](https://tails.boum.org/ "Tails")
+  * [persistent volume feature](https://tails.boum.org/doc/first_steps/persistence/index.en.html "persistent volume feature")
+  * [VeraCrypt](https://veracrypt.fr/en "VeraCrypt")
+  * [Defeating Plausible Deniability of VeraCrypt Hidden Operating Systems](https://ro.uow.edu.au/cgi/viewcontent.cgi?article=1542&context=eispapers1 "Defeating Plausible Deniability of VeraCrypt Hidden Operating Systems") — This paper analyzes the security of VeraCrypt hidden operating systems. 
+  * [How To Emulate Persistent Memory using the Linux "memmap" Kernel Option](https://pmem.io/knowledgebase/howto/100000012-how-to-emulate-persistent-memory-using-the-linux-memmapkernel-option/ "How To Emulate Persistent Memory using the Linux "memmap" Kernel Option")
+  * [kexec [ArchWiki]](https://wiki.archlinux.org/title/kexec "kexec 
+           \[ArchWiki\]")
+  * [Unplugged Core Membership](https://unpluggedcore.com/ "Unplugged Core Membership")
+  * [PodHome.FM](http://podhome.fm/ "PodHome.FM") — Unlimited Shows and Episodes
+  * [PodBean Example: This Week in Bitcoin Podcast](https://www.podbean.com/media/share/dir-8cqjw-1df1e6bf "PodBean Example: This Week in Bitcoin Podcast")
+  * [Atuin - Magical Shell History](https://atuin.sh/ "Atuin - Magical Shell History") — Sync, search and backup shell history with Atuin
+  * [I quit my job to work full time on my open source project](https://ellie.wtf/posts/i-quit-my-job-to-work-full-time-on-my-open-source-project "I quit my job to work full time on my open source project") — The 22nd of December was my last day leading the infrastructure team at PostHog. Going forwards, I'm starting a company and working full time on Atuin.
+
+
+
+## Tags
+
+[btrfs](https://linuxunplugged.com/tags/btrfs), [core rope memory](https://linuxunplugged.com/tags/core%20rope%20memory), [dns](https://linuxunplugged.com/tags/dns), [encryption](https://linuxunplugged.com/tags/encryption), [floppy disk](https://linuxunplugged.com/tags/floppy%20disk), [hiddenvm](https://linuxunplugged.com/tags/hiddenvm), [home assistant](https://linuxunplugged.com/tags/home%20assistant), [homekit](https://linuxunplugged.com/tags/homekit), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kexec](https://linuxunplugged.com/tags/kexec), [lightning network](https://linuxunplugged.com/tags/lightning%20network), [lightspark](https://linuxunplugged.com/tags/lightspark), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [nixos](https://linuxunplugged.com/tags/nixos), [nostr](https://linuxunplugged.com/tags/nostr), [nvdimm](https://linuxunplugged.com/tags/nvdimm), [persistent memory](https://linuxunplugged.com/tags/persistent%20memory), [plausible deniability](https://linuxunplugged.com/tags/plausible%20deniability), [pmem](https://linuxunplugged.com/tags/pmem), [ram disk](https://linuxunplugged.com/tags/ram%20disk), [security](https://linuxunplugged.com/tags/security), [shufflecake](https://linuxunplugged.com/tags/shufflecake), [subvolumes](https://linuxunplugged.com/tags/subvolumes), [tails](https://linuxunplugged.com/tags/tails), [truecrypt](https://linuxunplugged.com/tags/truecrypt), [veracrypt](https://linuxunplugged.com/tags/veracrypt), [virtualbox](https://linuxunplugged.com/tags/virtualbox), [xz](https://linuxunplugged.com/tags/xz)

--- a/docs/linux-unplugged/2024/episode-558.md
+++ b/docs/linux-unplugged/2024/episode-558.md
@@ -1,0 +1,44 @@
+# LUP 558: Top 5 Essential Apps
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+nivaY_6S?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-04-14
+* Duration: 53 mins 22 secs
+
+## About this episode
+
+We asked, and you answered: Your top 5 Linux app essentials and post-install rituals. Plus, some news to better cope with "extreme file-system damage."
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://kolide.com/unplugged)
+
+
+
+## Episode links
+
+  * [Berlin with Brent: May Meetup](https://www.meetup.com/jupiterbroadcasting/events/300421212/ "Berlin with Brent: May Meetup") — Brent is back in Berlin! Please join the Jupiter Broadcasting community for an evening together, and bring your friends!
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged on Fountain.FM")
+  * [Warp](https://apps.gnome.org/Warp/ "Warp") — Warp allows you to securely send files to each other via the internet or local network by exchanging a word-based code.
+  * [Bcachefs Repair Code Reaching Complete & Robust Recovery](https://www.phoronix.com/news/Bcachefs-Repair-Looking-Good "Bcachefs Repair Code Reaching Complete & Robust Recovery") — "This patchset was kindly tested by a user from India who accidentally wiped one drive out of a three drive filesystem with no replication on the family computer - it took a couple weeks but we got everything important back."
+  * [Linux 6.9-rc3 Released With Many Bcachefs Patches](https://www.phoronix.com/news/Linux-6.9-rc3-Released "Linux 6.9-rc3 Released With Many Bcachefs Patches") — "[...] but hey, if you had a corrupted bcachefs filesystem you'd probably want this, and if you thought bcachefs was stable already, I have a bridge to sell you. Special deal only for you, real cheap."
+  * [Fedora 42 Change Proposal Wants To Make KDE Plasma The Default Over GNOME](https://www.phoronix.com/news/Fedora-Change-KDE-Default-Prop "Fedora 42 Change Proposal Wants To Make KDE Plasma The Default Over GNOME")
+  * [F42 Change Proposal: Fedora Plasma Workstation](https://discussion.fedoraproject.org/t/f42-change-proposal-fedora-plasma-workstation-system-wide/111343 "F42 Change Proposal: Fedora Plasma Workstation") — Switch the default desktop experience for Workstation to KDE Plasma. The GNOME desktop is moved to a separate spin / edition, retaining release-blocking status.
+  * [Changes/FedoraPlasmaWorkstation - Fedora Project Wiki](https://fedoraproject.org/wiki/Changes/FedoraPlasmaWorkstation "Changes/FedoraPlasmaWorkstation - Fedora Project Wiki")
+  * [412linux.io](http://412linux.io/ "412linux.io") — N100 Media Serving Efficiency with Quick Sync
+  * [Pick: FreeTube](https://flathub.org/apps/io.freetubeapp.FreeTube "Pick: FreeTube") — FreeTube is an open source desktop YouTube player built with privacy in mind. Use YouTube without advertisements and prevent Google from tracking you with their cookies and JavaScript. Available for Windows, Mac & Linux thanks to Electron.
+  * [FreeBSD Speedruns](https://wiki.freebsd.org/Speedruns "FreeBSD Speedruns") — The zero-to-desktop FreeBSD speedrun category records the time taken from the first boot of a FreeBSD image, through installation, to the display of a desktop environment or window manager.
+  * [FreeBSD Zero to Desktop Speedrun Challenge](https://vermaden.wordpress.com/2024/04/05/freebsd-zero-to-desktop-speedrun-challenge/ "FreeBSD Zero to Desktop Speedrun Challenge") — The operations and commands that needed to be done took me 1:33 and installation of base.txz/kernel.txz datasets took 0:28. Downloading and installing needed pkg(8) packages took 2:22 of time.
+
+
+
+## Tags
+
+[alessandro astone](https://linuxunplugged.com/tags/alessandro%20astone), [aqua voice](https://linuxunplugged.com/tags/aqua%20voice), [bcachefs](https://linuxunplugged.com/tags/bcachefs), [beelink](https://linuxunplugged.com/tags/beelink), [berlin](https://linuxunplugged.com/tags/berlin), [bitwarden](https://linuxunplugged.com/tags/bitwarden), [brave](https://linuxunplugged.com/tags/brave), [budgie](https://linuxunplugged.com/tags/budgie), [codium](https://linuxunplugged.com/tags/codium), [dictation](https://linuxunplugged.com/tags/dictation), [doom emacs](https://linuxunplugged.com/tags/doom%20emacs), [duf](https://linuxunplugged.com/tags/duf), [element](https://linuxunplugged.com/tags/element), [fd](https://linuxunplugged.com/tags/fd), [fedora 42](https://linuxunplugged.com/tags/fedora%2042), [fedora plasma workstation](https://linuxunplugged.com/tags/fedora%20plasma%20workstation), [firefox](https://linuxunplugged.com/tags/firefox), [fish](https://linuxunplugged.com/tags/fish), [flakes](https://linuxunplugged.com/tags/flakes), [flathub](https://linuxunplugged.com/tags/flathub), [freetube](https://linuxunplugged.com/tags/freetube), [gnome](https://linuxunplugged.com/tags/gnome), [joshua strobl](https://linuxunplugged.com/tags/joshua%20strobl), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [keepassxc](https://linuxunplugged.com/tags/keepassxc), [linux 6.9](https://linuxunplugged.com/tags/linux%206.9), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [logseq](https://linuxunplugged.com/tags/logseq), [marc deop i argemí](https://linuxunplugged.com/tags/marc%20deop%20i%20argem%C3%AD), [meetup](https://linuxunplugged.com/tags/meetup), [mentat](https://linuxunplugged.com/tags/mentat), [mentat nextcloud](https://linuxunplugged.com/tags/mentat%20nextcloud), [mumble](https://linuxunplugged.com/tags/mumble), [nix-command](https://linuxunplugged.com/tags/nix-command), [nix.settings.experimental-features](https://linuxunplugged.com/tags/nix.settings.experimental-features), [nixos](https://linuxunplugged.com/tags/nixos), [onlyoffice](https://linuxunplugged.com/tags/onlyoffice), [password manager](https://linuxunplugged.com/tags/password%20manager), [pcloud](https://linuxunplugged.com/tags/pcloud), [proton pass](https://linuxunplugged.com/tags/proton%20pass), [qownnotes](https://linuxunplugged.com/tags/qownnotes), [remmina](https://linuxunplugged.com/tags/remmina), [ripgrep](https://linuxunplugged.com/tags/ripgrep), [signal](https://linuxunplugged.com/tags/signal), [solus linux](https://linuxunplugged.com/tags/solus%20linux), [spotify](https://linuxunplugged.com/tags/spotify), [steam](https://linuxunplugged.com/tags/steam), [steve cossette](https://linuxunplugged.com/tags/steve%20cossette), [syncthing](https://linuxunplugged.com/tags/syncthing), [tailscale](https://linuxunplugged.com/tags/tailscale), [telegram](https://linuxunplugged.com/tags/telegram), [ticktick](https://linuxunplugged.com/tags/ticktick), [topgrade](https://linuxunplugged.com/tags/topgrade), [troy dawson](https://linuxunplugged.com/tags/troy%20dawson)

--- a/docs/linux-unplugged/2024/episode-559.md
+++ b/docs/linux-unplugged/2024/episode-559.md
@@ -1,0 +1,60 @@
+# LUP 559: Linux is Bigger in Texas
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+LCiHYhl7?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-04-21
+* Duration: 90 mins 37 secs
+
+## About this episode
+
+We're back from Austin, with interviews and stories to share. Plus, it's Gentoo week and we take our first look at Fedora 40.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://kolide.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged on Fountain.FM")
+  * [Fedora 40 beta is fastest operating system I've tested](https://www.zdnet.com/article/fedora-40-beta-is-fastest-operating-system-ive-tested-and-its-full-of-useful-features/ "Fedora 40 beta is fastest operating system I've tested") — Apps opened in the blink of an eye. The Overview appeared instantly. Everything seemed to be built around the idea that the user works at the speed of madness and the OS is there to help make it happen.
+  * [Fedora Linux 40 Docs](https://docs.fedoraproject.org/en-US/releases/f40/ "Fedora Linux 40 Docs")
+  * [Fedora Linux 40 Cleared For Release](https://www.phoronix.com/news/Fedora-40-Next-Week "Fedora Linux 40 Cleared For Release") — Fedora 40 thus will see its official release happen next Tuesday, 23 April.
+  * [F40 Change Proposal: Drop Delta RPMs](https://discussion.fedoraproject.org/t/f40-change-proposal-drop-delta-rpms-system-wide/89601 "F40 Change Proposal: Drop Delta RPMs") — According to early feedback from Release Engineering, it looks like it will not be feasible to address the shortcomings of Delta RPMs as they are currently implemented, and since they often no longer result in a net reduction in download sizes for upgrades, this Change proposes both to disable the generation of DeltaRPMs during the compose process, and to disable the deltarpm support in dnf / dnf5 by default.
+  * [Berlin with Brent May Meetup](https://www.meetup.com/jupiterbroadcasting/events/300421212/ "Berlin with Brent May Meetup") — May 11, 2024
+  * [LinuxFest Northwest 2025](https://linuxfestnorthwest.org/ "LinuxFest Northwest 2025") — April 26 - 28, 2024
+  * [System76 and Jupiter Broadcasting Epic Parking Lot BBQ](https://www.meetup.com/system76-community/events/299957317/ "System76 and Jupiter Broadcasting Epic Parking Lot BBQ") — Sat, Apr 27, 2024, 12:00 PM
+  * [LFNW Talk: 5 Reasons to Love NixOS](https://lfnw2024.sessionize.com/session/598377 "LFNW Talk: 5 Reasons to Love NixOS") — NixOS seems to be everywhere these days and has the fanatic energy usually reserved for Arch users. But WHY is it so popular? In this talk, I'll go over 5 reasons I love NixOS and you might too.
+  * [LFNW Talk: Deploying NixOS Anywhere](https://lfnw2024.sessionize.com/session/603318 "LFNW Talk: Deploying NixOS Anywhere") — In this talk, we'll unlock the full potential of NixOS by exploring how its unique architecture enables installation just about anywhere—from bare metal and VMs to a VPS provider near you.
+  * [LFNW Talk: LINUX Unplugged LIVE](https://lfnw2024.sessionize.com/session/625989 "LFNW Talk: LINUX Unplugged LIVE") — We're recording a live edition of LINUX Unplugged in person. Our weekly Linux talk show with no script, no limits, surprise guests, and tons of opinions. 
+  * [Scinary Cybersecurity](https://www.scinary.com/ "Scinary Cybersecurity") — Founded in 2015, we are proud to be one of few full-service cybersecurity firms focused on small and midsized governmental entities. Serving clients in mutiple states, we provide quality services and solutions that best fit your needs.
+  * [Jupiter Extras](https://extras.show/91 "Jupiter Extras") — Texas LinuxFest Day 1
+  * [Jupiter Extras](https://extras.show/92 "Jupiter Extras") — Texas LinuxFest Day 2
+  * [Texas Linux Festival 2024](https://2024.texaslinuxfest.org/ "Texas Linux Festival 2024") — Texas Linux Fest is the first state-wide annual community-run conference for Linux and open source software users and enthusiasts from around the Lone Star State.
+  * [MIL-STD-1553](https://en.wikipedia.org/wiki/MIL-STD-1553 "MIL-STD-1553") — MIL-STD-1553 is a military standard published by the United States Department of Defense that defines the mechanical, electrical, and functional characteristics of a serial data bus.
+  * [Chris' Cave Pictures](https://primal.net/e/note1cmhw4p2wzqugvra7c5eh4ajxds9yjy4t3rxq2uhzzxyyyvepytesezma8m "Chris' Cave Pictures")
+  * [Buc-ees](https://buc-ees.com/about/ "Buc-ees") — If you've been to Buc-ee's, you may already know that this friendly neighbor along the highways has the cleanest restrooms in America. In 2012, Cintas ran a nationwide restroom contest and made it official!
+  * [Street Fighter 2 Music](https://jb-community.us-southeast-1.linodeobjects.com/sf2_intro_track.mp3 "Street Fighter 2 Music") — Arcade Intro
+  * [Street Fighter 2 Music](https://jb-community.us-southeast-1.linodeobjects.com/ssf2hd_intro_ocremix.mp3 "Street Fighter 2 Music") — OC Remix
+  * [UEFI Boot Standalone NixOS (2024-04-20)](https://github.com/tpwrules/nixos-apple-silicon/blob/main/docs/uefi-standalone.md "UEFI Boot Standalone NixOS \(2024-04-20\)") — This guide will explain how to install NixOS on the internal NVMe drive of an Apple Silicon Mac using a customized version of the official NixOS install ISO, then boot it without the help of another computer.
+  * [TeX Shinobi Keyboard](https://tex.com.tw/products/shinobi?variant=16969883648090 "TeX Shinobi Keyboard")
+  * [nixos-conf-editor](http://github.com/snowfallorg/nixos-conf-editor "nixos-conf-editor") — A libadwaita/gtk4 app for editing NixOS configurations.
+  * [nix-software-center](http://github.com/snowfallorg/nix-software-center "nix-software-center") — A simple gtk4/libadwaita software center to easily install and manage nix packages.
+  * [bhh32's app installer](https://github.com/bhh32/installer "bhh32's app installer")
+  * [dharple/detox](https://github.com/dharple/detox "dharple/detox") — Tames problematic filenames
+  * [Jovian NixOS](https://github.com/Jovian-Experiments/Jovian-NixOS "Jovian NixOS") — NixOS on the Steam Deck
+  * [Pick: Shortwave](https://flathub.org/apps/de.haeckerfelix.Shortwave "Pick: Shortwave") — Shortwave is an internet radio player that provides access to a station database with over 30,000 stations, including Jupiter Broadcasting.
+
+
+
+## Tags
+
+[adam curry](https://linuxunplugged.com/tags/adam%20curry), [atuin](https://linuxunplugged.com/tags/atuin), [bbq](https://linuxunplugged.com/tags/bbq), [boostagram ball](https://linuxunplugged.com/tags/boostagram%20ball), [brent's ergonomic interest](https://linuxunplugged.com/tags/brent's%20ergonomic%20interest), [buc-ees](https://linuxunplugged.com/tags/buc-ees), [carl george](https://linuxunplugged.com/tags/carl%20george), [delta rpm](https://linuxunplugged.com/tags/delta%20rpm), [docker](https://linuxunplugged.com/tags/docker), [fedora 40](https://linuxunplugged.com/tags/fedora%2040), [frank karlitschek](https://linuxunplugged.com/tags/frank%20karlitschek), [gentoo week](https://linuxunplugged.com/tags/gentoo%20week), [gl-inet](https://linuxunplugged.com/tags/gl-inet), [gnome](https://linuxunplugged.com/tags/gnome), [great a’tuin](https://linuxunplugged.com/tags/great%20a%E2%80%99tuin), [home assistant](https://linuxunplugged.com/tags/home%20assistant), [honeywell](https://linuxunplugged.com/tags/honeywell), [iss](https://linuxunplugged.com/tags/iss), [jovian nixos](https://linuxunplugged.com/tags/jovian%20nixos), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [jupiter extras](https://linuxunplugged.com/tags/jupiter%20extras), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [logseq](https://linuxunplugged.com/tags/logseq), [longhorn cavern state park](https://linuxunplugged.com/tags/longhorn%20cavern%20state%20park), [mac mini m1](https://linuxunplugged.com/tags/mac%20mini%20m1), [nixos](https://linuxunplugged.com/tags/nixos), [nixos gui editor](https://linuxunplugged.com/tags/nixos%20gui%20editor), [plasma](https://linuxunplugged.com/tags/plasma), [qubes on nixos](https://linuxunplugged.com/tags/qubes%20on%20nixos), [qubesos](https://linuxunplugged.com/tags/qubesos), [scinary](https://linuxunplugged.com/tags/scinary), [self](https://linuxunplugged.com/tags/self), [shortwave](https://linuxunplugged.com/tags/shortwave), [steam deck](https://linuxunplugged.com/tags/steam%20deck), [system76](https://linuxunplugged.com/tags/system76), [ted gould](https://linuxunplugged.com/tags/ted%20gould), [tex shinobi keyboard](https://linuxunplugged.com/tags/tex%20shinobi%20keyboard), [texas linuxfest](https://linuxunplugged.com/tags/texas%20linuxfest), [txlf](https://linuxunplugged.com/tags/txlf), [v4v](https://linuxunplugged.com/tags/v4v), [wireshark](https://linuxunplugged.com/tags/wireshark)

--- a/docs/linux-unplugged/2024/episode-560.md
+++ b/docs/linux-unplugged/2024/episode-560.md
@@ -1,0 +1,46 @@
+# LUP 560: Linux Festivus For the Rest of Us
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+ngsTELK7?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-04-28
+* Duration: 75 mins 10 secs
+
+## About this episode
+
+The first LinuxFest is back and better than ever. We share stories and friends from one of the best Linux gatherings of the year: LinuxFest Northwest.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+* [Alex Kretzschmar](https://linuxunplugged.com/guests/alexktz)
+* [Noah Chelliah](https://linuxunplugged.com/guests/kernellinux)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://kolide.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged on Fountain.FM")
+  * [LinuxFest Northwest 2024](https://linuxfestnorthwest.org/ "LinuxFest Northwest 2024") — An annual open-source event co-produced by Bellingham Linux Users Group, the Information Technology department at BTC, Cascade STEAM, and Jupiter Broadcasting.
+  * [Bellingham Technical College](https://www.btc.edu/ "Bellingham Technical College") — At BTC, we're here to help you access the hands-on education that can give you an advantage in today's job market.
+  * [Ubuntu 24.04 LTS Downloads Now Available](https://www.phoronix.com/news/Ubuntu-24.04-LTS-Download "Ubuntu 24.04 LTS Downloads Now Available") — Ubuntu 24.04 is an exciting Long Term Support (LTS) update with this new Linux distribution release being powered by the Linux 6.8 kernel, making use of Netplan for networking on the desktop, features the modernized desktop OS installer, various performance optimizations, and a ton of new features.
+  * [x32-proxy](https://github.com/audiopump/x32-proxy "x32-proxy") — UDP and Web Socket proxy server for Behringer and Midas digital mixer control.
+  * [LinuxFest Northwest YouTube](https://www.youtube.com/@LinuxFestNorthwest "LinuxFest Northwest YouTube")
+  * [Peyton's GitHub](https://github.com/p1diddy "Peyton's GitHub")
+  * [Electromagnetic Field ](http://emfcamp.org/ "Electromagnetic Field ") — A non-profit camping festival for those with an inquisitive mind or an interest in making things: hackers, artists, geeks, crafters, scientists, and engineers.
+  * [completenoob's NixOS ZFS on Root Setup](https://www.completenoobs.com/noobs/NixOS_ZFS_Encryption_on_root "completenoob's NixOS ZFS on Root Setup") — Install NixOS with ZFS on root on a ThinkPad T470 with 24gb Ram and a 1TB nvme ssd.
+  * [radio-browser.info](http://radio-browser.info/ "radio-browser.info") — This is a community driven effort (like wikipedia) with the aim of collecting as many internet radio and TV stations as possible. Any help is appreciated!
+  * [Pick: Playlifin](https://flathub.org/apps/net.krafting.Playlifin "Pick: Playlifin") — A tool to convert a Youtube Music playlist to a Jellyfin playlists.
+  * [Pick: Playlifin Voyager](https://flathub.org/apps/net.krafting.PlaylifinVoyager "Pick: Playlifin Voyager") — Playlifin Voyager is a tool to export and import playlists from and to your Jellyfin Server.
+
+
+
+## Tags
+
+[amd sev-snp](https://linuxunplugged.com/tags/amd%20sev-snp), [apparmor 4](https://linuxunplugged.com/tags/apparmor%204), [bbq](https://linuxunplugged.com/tags/bbq), [bug bounty](https://linuxunplugged.com/tags/bug%20bounty), [compile-time bounds checking](https://linuxunplugged.com/tags/compile-time%20bounds%20checking), [festivus](https://linuxunplugged.com/tags/festivus), [for the rest of us](https://linuxunplugged.com/tags/for%20the%20rest%20of%20us), [grok](https://linuxunplugged.com/tags/grok), [intel shadow stack](https://linuxunplugged.com/tags/intel%20shadow%20stack), [intel tdx](https://linuxunplugged.com/tags/intel%20tdx), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kolide](https://linuxunplugged.com/tags/kolide), [linux](https://linuxunplugged.com/tags/linux), [linux kernel v6.8](https://linuxunplugged.com/tags/linux%20kernel%20v6.8), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [linuxfest northwest 2024](https://linuxunplugged.com/tags/linuxfest%20northwest%202024), [llama3](https://linuxunplugged.com/tags/llama3), [llamafile 0.8](https://linuxunplugged.com/tags/llamafile%200.8), [maintenance](https://linuxunplugged.com/tags/maintenance), [ms-dos 4.0](https://linuxunplugged.com/tags/ms-dos%204.0), [security](https://linuxunplugged.com/tags/security), [systemd](https://linuxunplugged.com/tags/systemd), [tailscale](https://linuxunplugged.com/tags/tailscale), [tls](https://linuxunplugged.com/tags/tls), [ubuntu 24.04 lts](https://linuxunplugged.com/tags/ubuntu%2024.04%20lts)

--- a/docs/linux-unplugged/2024/episode-561.md
+++ b/docs/linux-unplugged/2024/episode-561.md
@@ -1,0 +1,51 @@
+# LUP 561: Folders as a Service
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+O3RIKMzq?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-05-05
+* Duration: 43 mins 23 secs
+
+## About this episode
+
+A few of our go-to tools for one-liner web servers, sharing media directly from folders, and a much needed live Arch server update, and more!
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://kolide.com/unplugged)
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&amp;coupon=may): [Save $3 a month on your membership, and get the Bootleg and ad-free version of the show. Code: MAY](https://jupitersignal.memberful.com/checkout?plan=52946&amp;coupon=may)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged on Fountain.FM")
+  * [Berlin with Brent](https://www.meetup.com/jupiterbroadcasting/events/300421212/ "Berlin with Brent") — May Meetup, Sat, May 11, 2024, 6:30 PM CEST
+  * [Linuxfest Northwest 2024 Videos](https://www.youtube.com/@LinuxFestNorthwest/videos "Linuxfest Northwest 2024 Videos")
+  * [Tiny File Manager](https://tinyfilemanager.github.io/ "Tiny File Manager") — Web based File Manager in PHP, Manage your files efficiently and easily with Tiny File Manager and it is a simple, fast and small file manager with a single file.
+  * [Tiny File Manager Password Options](https://github.com/prasathmani/tinyfilemanager/wiki/Security-and-User-Management#configuration "Tiny File Manager Password Options")
+  * [Tiny File Manager Project Demo](https://tinyfilemanager.github.io/demo/ "Tiny File Manager Project Demo")
+  * [noblepayne/tinyfilemanager-flake](https://github.com/noblepayne/tinyfilemanager-flake "noblepayne/tinyfilemanager-flake") — nix run github:noblepayne/tinyfilemanager-flake
+  * [Big list of http static server one-liners](https://gist.github.com/willurd/5720255 "Big list of http static server one-liners") — python -m http.server 8000
+  * [awesome-webservers: ⚙️](https://github.com/imgarylai/awesome-webservers "awesome-webservers: ⚙️") — Collection of one-liner static servers.
+  * [static-web-server](https://github.com/static-web-server/static-web-server "static-web-server") — A cross-platform, high-performance and asynchronous web server for static files-serving. ⚡
+  * [The smallest Docker image to serve static websites](https://lipanski.com/posts/smallest-docker-image-static-website "The smallest Docker image to serve static websites")
+  * [Self-Hosted 122: Back to the Future](https://selfhosted.show/122 "Self-Hosted 122: Back to the Future") — How Chris created live TV streaming from his local media collection, Alex breaks down the new Open Home Foundation and what it means for self-hosters. Brent's been trying out an open-source AirDrop replacement for all systems, and much more!
+  * [LocalSend](https://github.com/localsend/localsend "LocalSend") — An open-source cross-platform alternative to AirDrop.
+  * [🌷 Spring Membership Discount 🌱](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=may "🌷 Spring Membership Discount 🌱") — Promo code: MAY
+  * [SouthEast LinuxFest](https://southeastlinuxfest.org/ "SouthEast LinuxFest") — June 7-9, 2024 in Charlotte, NC.
+  * [Boost LINUX Unplugged on Fountain’s Website](https://fountain.fm/show/dWiuBeqpDSM86AwXRXov "Boost LINUX Unplugged on Fountain’s Website")
+  * [Pick: audioserve](https://github.com/izderadicka/audioserve "Pick: audioserve") — Simple personal server to serve audiofiles files from folders. Intended primarily for audio books, but anything with decent folder structure will do.
+  * [Neofetch is Dead! Here are 7 Alternatives for Your Linux System](https://itsfoss.com/neofetch-alternatives/ "Neofetch is Dead! Here are 7 Alternatives for Your Linux System")
+
+
+
+## Tags
+
+[1st linux box](https://linuxunplugged.com/tags/1st%20linux%20box), [airdrop alternative](https://linuxunplugged.com/tags/airdrop%20alternative), [ajax](https://linuxunplugged.com/tags/ajax), [arch server](https://linuxunplugged.com/tags/arch%20server), [arch update](https://linuxunplugged.com/tags/arch%20update), [audioserve](https://linuxunplugged.com/tags/audioserve), [awesome-webservers](https://linuxunplugged.com/tags/awesome-webservers), [bbq](https://linuxunplugged.com/tags/bbq), [campus surplus](https://linuxunplugged.com/tags/campus%20surplus), [docker](https://linuxunplugged.com/tags/docker), [files](https://linuxunplugged.com/tags/files), [folders as a service](https://linuxunplugged.com/tags/folders%20as%20a%20service), [fountain.fm](https://linuxunplugged.com/tags/fountain.fm), [fun with files](https://linuxunplugged.com/tags/fun%20with%20files), [homelab](https://linuxunplugged.com/tags/homelab), [http static server](https://linuxunplugged.com/tags/http%20static%20server), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [lfnw](https://linuxunplugged.com/tags/lfnw), [linux for windows](https://linuxunplugged.com/tags/linux%20for%20windows), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [linuxfest northwest](https://linuxunplugged.com/tags/linuxfest%20northwest), [little server that could](https://linuxunplugged.com/tags/little%20server%20that%20could), [live upgrade](https://linuxunplugged.com/tags/live%20upgrade), [localsend](https://linuxunplugged.com/tags/localsend), [maple syrup pour](https://linuxunplugged.com/tags/maple%20syrup%20pour), [neofetch](https://linuxunplugged.com/tags/neofetch), [nix drama](https://linuxunplugged.com/tags/nix%20drama), [nix flake](https://linuxunplugged.com/tags/nix%20flake), [nixos](https://linuxunplugged.com/tags/nixos), [no auth required](https://linuxunplugged.com/tags/no%20auth%20required), [photosynth](https://linuxunplugged.com/tags/photosynth), [php](https://linuxunplugged.com/tags/php), [podman](https://linuxunplugged.com/tags/podman), [production arch server](https://linuxunplugged.com/tags/production%20arch%20server), [rolling distro](https://linuxunplugged.com/tags/rolling%20distro), [rust](https://linuxunplugged.com/tags/rust), [self](https://linuxunplugged.com/tags/self), [slackware](https://linuxunplugged.com/tags/slackware), [southeast linuxfest](https://linuxunplugged.com/tags/southeast%20linuxfest), [spaceballs boost](https://linuxunplugged.com/tags/spaceballs%20boost), [sputnik](https://linuxunplugged.com/tags/sputnik), [tiny file manager](https://linuxunplugged.com/tags/tiny%20file%20manager), [wes’ janky options](https://linuxunplugged.com/tags/wes%E2%80%99%20janky%20options), [winmodem](https://linuxunplugged.com/tags/winmodem), [yellow dog linux](https://linuxunplugged.com/tags/yellow%20dog%20linux)

--- a/docs/linux-unplugged/2024/episode-562.md
+++ b/docs/linux-unplugged/2024/episode-562.md
@@ -1,0 +1,53 @@
+# LUP 562: Red Hat Knows How to Party
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+s26nC5qr?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-05-12
+* Duration: 74 mins 45 secs
+
+## About this episode
+
+Three revelations from Red Hat Summit. Our on-the-ground report will separate fact from hype.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://kolide.com/unplugged)
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&amp;coupon=may): [Save $3 a month on your membership, and get the Bootleg and ad-free version of the show. Code: MAY](https://jupitersignal.memberful.com/checkout?plan=52946&amp;coupon=may)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged on Fountain.FM")
+  * [Introducing image mode for Red Hat Enterprise Linux](https://www.redhat.com/en/blog/introducing-image-mode-red-hat-enterprise-linux "Introducing image mode for Red Hat Enterprise Linux") — Image mode for Red Hat Enterprise Linux is a new deployment method that takes a container-native approach to deliver the OS as a bootc container image.
+  * [Image mode for Red Hat Enterprise Linux Overview](https://developers.redhat.com/products/rhel-image-mode/overview "Image mode for Red Hat Enterprise Linux Overview")
+  * [Image mode for Red Hat Enterprise Linux YouTube Example](https://www.youtube.com/watch?v=Rby_0yF9b5Y "Image mode for Red Hat Enterprise Linux YouTube Example")
+  * [podman-desktop-extension-bootc](https://github.com/containers/podman-desktop-extension-bootc "podman-desktop-extension-bootc") — Support for bootable OS containers (bootc) and generating disk images.
+  * [bootc Introduction](https://containers.github.io/bootc/ "bootc Introduction") — Transactional, in-place operating system updates using OCI/Docker container images. bootc is the key component in a broader mission of bootable containers.
+  * [Show HN: Convert your Containerfile to a bootable OS](https://news.ycombinator.com/item?id=40289120 "Show HN: Convert your Containerfile to a bootable OS")
+  * [What is InstructLab?](https://www.redhat.com/en/topics/ai/what-is-instructlab "What is InstructLab?") — InstructLab is an open source project for enhancing large language models (LLMs) used in generative artificial intelligence (gen AI) applications.
+  * [InstructLab](https://github.com/instructlab "InstructLab") — InstructLab is a model-agnostic open source AI project that facilitates contributions to Large Language Models (LLMs).
+  * [instructlab CLI](https://github.com/instructlab/instructlab "instructlab CLI") — Command-line interface. Use this to chat with the model or train the model (training consumes the taxonomy data).
+  * [IBM's Granite code model family is going open source](https://research.ibm.com/blog/granite-code-models-open-source "IBM's Granite code model family is going open source") — We're releasing a series of decoder-only Granite code models for code generative tasks, trained with code written in 116 programming languages. The Granite code models family consists of models ranging in size from 3 to 34 billion parameters, in both a base model and instruction-following model variants.
+  * [ibm-granite/granite-code-models](https://github.com/ibm-granite/granite-code-models "ibm-granite/granite-code-models") — A Family of Open Foundation Models for Code Intelligence.
+  * [Getting Started with Fedora/CentOS bootc](https://docs.fedoraproject.org/en-US/bootc/ "Getting Started with Fedora/CentOS bootc") — The Fedora/CentOS bootc project generates reference base images that are designed for use with the bootc project. Its goal is to provide a host system easily configurable via container tooling, usable as a container host, but also to allow non-containerized deployments with applications bound to the host context.
+  * [CentOS/centos-bootc](https://github.com/CentOS/centos-bootc "CentOS/centos-bootc") — Create and maintain base bootable container images from Fedora ELN and CentOS Stream packages.
+  * [LAB Paper: Large-Scale Alignment for ChatBots](https://arxiv.org/abs/2403.01081 "LAB Paper: Large-Scale Alignment for ChatBots")
+  * [Spring Membership Discount](https://jupitersignal.memberful.com/checkout?plan=74364&coupon=may "Spring Membership Discount") — $3 off forever.
+  * [psitransfer](https://github.com/psi-4ward/psitransfer "psitransfer") — Simple open source self-hosted file sharing solution. It's an alternative to paid services like Dropbox, WeTransfer.
+  * [bhh32's food-journal](https://github.com/bhh32/food-journal "bhh32's food-journal") — Command line tool and web application to keep track of my food intake.
+  * [Pick: URL to PNG](https://jasonraimondi.github.io/url-to-png/ "Pick: URL to PNG") — A URL to PNG generator over HTTP with a fairly simple API accessed via query params passed to the server.
+  * [Bonus Pick: Telegraph](https://flathub.org/apps/io.github.fkinoshita.Telegraph "Bonus Pick: Telegraph") — Telegraph is a simple Morse translator, start typing your message to see the resulting Morse code and vice versa.
+
+
+
+## Tags
+
+[ai](https://linuxunplugged.com/tags/ai), [announcement links](https://linuxunplugged.com/tags/announcement%20links), [berlin meetup report](https://linuxunplugged.com/tags/berlin%20meetup%20report), [block party](https://linuxunplugged.com/tags/block%20party), [bootc](https://linuxunplugged.com/tags/bootc), [centos](https://linuxunplugged.com/tags/centos), [expo hall](https://linuxunplugged.com/tags/expo%20hall), [fedora](https://linuxunplugged.com/tags/fedora), [granite code model](https://linuxunplugged.com/tags/granite%20code%20model), [ibm](https://linuxunplugged.com/tags/ibm), [image mode](https://linuxunplugged.com/tags/image%20mode), [instructlab](https://linuxunplugged.com/tags/instructlab), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [keynote](https://linuxunplugged.com/tags/keynote), [lab](https://linuxunplugged.com/tags/lab), [large-scale alignment for chatbots](https://linuxunplugged.com/tags/large-scale%20alignment%20for%20chatbots), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [lup phone](https://linuxunplugged.com/tags/lup%20phone), [podman](https://linuxunplugged.com/tags/podman), [red hat](https://linuxunplugged.com/tags/red%20hat), [red hat enterprise linux](https://linuxunplugged.com/tags/red%20hat%20enterprise%20linux), [rhel](https://linuxunplugged.com/tags/rhel), [summit](https://linuxunplugged.com/tags/summit)

--- a/docs/linux-unplugged/2024/episode-563.md
+++ b/docs/linux-unplugged/2024/episode-563.md
@@ -1,0 +1,49 @@
+# LUP 563: Nix's People Problem
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+sw5fTPKu?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-05-19
+* Duration: 61 mins 27 secs
+
+## About this episode
+
+After months of debate, the Nix community might be coming to a resolution. We'll examine what happened, what's changing.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Alex Kretzschmar](https://linuxunplugged.com/guests/alexktz)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://kolide.com/unplugged)
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&amp;coupon=may): [Save $3 a month on your membership, and get the Bootleg and ad-free version of the show. Code: MAY](https://jupitersignal.memberful.com/checkout?plan=52946&amp;coupon=may)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged on Fountain.FM")
+  * [Using Tailscale for Android just got a whole lot better](https://tailscale.com/blog/android "Using Tailscale for Android just got a whole lot better")
+  * [Report on NixOS Governance Discussions - by Chris McDonough](https://chrismcdonough.substack.com/p/report-on-nixos-governance-discussions "Report on NixOS Governance Discussions - by Chris McDonough")
+  * [The NixOS Foundation board announced on April 30 that Eelco Dolstra is stepping down from the board following the recent calls for his resignation.](https://lwn.net/Articles/971973/ "The NixOS Foundation board announced on April 30 that Eelco Dolstra is stepping down from the board following the recent calls for his resignation.")
+  * [A leadership crisis in the Nix community (LWN)](https://lwn.net/Articles/970824/ "A leadership crisis in the Nix community \(LWN\)") — On April 21, a group of anonymous authors and non-anonymous signatories published a lengthy open letter to the Nix community and Nix founder Eelco Dolstra calling for his resignation from the project.
+  * [NixOS Foundation board: Giving power to the community - Announcements - NixOS Discourse](https://discourse.nixos.org/t/nixos-foundation-board-giving-power-to-the-community/44552 "NixOS Foundation board: Giving power to the community - Announcements - NixOS Discourse")
+  * [NixOS Foundation Board: Constitutional Assembly Appointment - Announcements - NixOS Discourse](https://discourse.nixos.org/t/nixos-foundation-board-constitutional-assembly-appointment/45504 "NixOS Foundation Board: Constitutional Assembly Appointment - Announcements - NixOS Discourse")
+  * [Full Email with Graham](https://paste.docs.lol/reader/MintPoodle "Full Email with Graham")
+  * [Chris' s nginx Config](https://github.com/JupiterBroadcasting/nixconfigs/blob/main/nginx-ssl "Chris' s nginx Config")
+  * [NixOS Manual: Using DNS validation with web server virtual hosts](https://nixos.org/manual/nixos/stable/#module-security-acme-config-dns-with-vhosts "NixOS Manual: Using DNS validation with web server virtual hosts")
+  * [NixOS Manual: SSL/TLS Certificates with ACME](https://nixos.org/manual/nixos/stable/#module-security-acme "NixOS Manual: SSL/TLS Certificates with ACME")
+  * [Unplugged Core Membership](https://linuxunplugged.com/membership "Unplugged Core Membership")
+  * [Signing up with an email address](https://tailscale.com/kb/1013/sso-providers#signing-up-with-an-email-address "Signing up with an email address")
+  * [Dell OEM Replacement Parts](https://www.parts-people.com/ "Dell OEM Replacement Parts")
+  * [Winamp has announced that it is opening up its source](https://about.winamp.com/press/article/winamp-open-source-code "Winamp has announced that it is opening up its source") — Winamp has announced that on 24 September 2024, the application's source code will be open to developers worldwide.
+  * [RcloneShuttle](https://github.com/pieterdd/RcloneShuttle "RcloneShuttle") — Upload your files to anywhere - GTK4 GUI for Rclone
+
+
+
+## Tags
+
+[anduril](https://linuxunplugged.com/tags/anduril), [community](https://linuxunplugged.com/tags/community), [constitutional assembly](https://linuxunplugged.com/tags/constitutional%20assembly), [determinate.systems](https://linuxunplugged.com/tags/determinate.systems), [eelco dolstra](https://linuxunplugged.com/tags/eelco%20dolstra), [governance](https://linuxunplugged.com/tags/governance), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [military sponsorship](https://linuxunplugged.com/tags/military%20sponsorship), [moderation](https://linuxunplugged.com/tags/moderation), [nix](https://linuxunplugged.com/tags/nix), [nixos](https://linuxunplugged.com/tags/nixos), [nixos foundation](https://linuxunplugged.com/tags/nixos%20foundation), [open letter](https://linuxunplugged.com/tags/open%20letter)

--- a/docs/linux-unplugged/2024/episode-564.md
+++ b/docs/linux-unplugged/2024/episode-564.md
@@ -1,0 +1,43 @@
+# LUP 564: The Goldilocks Build
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+MX4THR-I?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-05-26
+* Duration: 65 mins 34 secs
+
+## About this episode
+
+We're following one simple rule to build a Linux desktop so stable it could outlive us.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://kolide.com/unplugged)
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&amp;coupon=may): [Save $3 a month on your membership, and get the Bootleg and ad-free version of the show. Code: MAY](https://jupitersignal.memberful.com/checkout?plan=52946&amp;coupon=may)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Microsoft’s controversial Recall feature for Windows 11 could already be in legal hot water](https://www.techradar.com/computing/windows/microsofts-controversial-recall-feature-for-windows-11-could-already-be-in-legal-hot-water "Microsoft’s controversial Recall feature for Windows 11 could already be in legal hot water")
+  * [Apple GPT](https://www.macrumors.com/guide/apple-gpt/ "Apple GPT") — What We Know About Apple's Work on Generative AI
+  * [Chris' BeeLink](https://www.amazon.com/dp/B0C2P486GQ "Chris' BeeLink") — Beelink Ryzen 7 5700U Up to 4.3GHz 8C/16T
+  * [RV BeeLink Nix configuration.nix](https://github.com/ChrisLAS/nix/blob/main/configuration.nix "RV BeeLink Nix configuration.nix")
+  * [Slack - NixOS Wiki](https://nixos.wiki/wiki/Slack "Slack - NixOS Wiki")
+  * [Chris' Win 7 Inspired Look](https://imgur.com/a/IjvHIUj "Chris' Win 7 Inspired Look")
+  * [musnix](https://github.com/musnix/musnix "musnix") — Real-time audio in NixOS
+  * [Boost Pick: nh](https://github.com/viperML/nh "Boost Pick: nh") — NH reimplements some basic nix commands. Adding functionality on top of the existing solutions, like nixos-rebuild, home-manager cli or nix itself.
+  * [Pick: gridplayer](https://github.com/vzhd1701/gridplayer "Pick: gridplayer") — Simple VLC-based media player that can play multiple videos at the same time. You can play as many videos as you like, the only limit is your hardware. It supports all video formats that VLC supports (which is all of them). You can save your playlist retaining information about the position, sound volume, loops, aspect ratio, etc.
+
+
+
+## Tags
+
+[beelink](https://linuxunplugged.com/tags/beelink), [beelink amd ryzen 7 5700u](https://linuxunplugged.com/tags/beelink%20amd%20ryzen%207%205700u), [declarative pc](https://linuxunplugged.com/tags/declarative%20pc), [example nix config](https://linuxunplugged.com/tags/example%20nix%20config), [fedora atomic](https://linuxunplugged.com/tags/fedora%20atomic), [gridplayer](https://linuxunplugged.com/tags/gridplayer), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kate](https://linuxunplugged.com/tags/kate), [kde](https://linuxunplugged.com/tags/kde), [krunner](https://linuxunplugged.com/tags/krunner), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [mac studio](https://linuxunplugged.com/tags/mac%20studio), [musnix](https://linuxunplugged.com/tags/musnix), [nh](https://linuxunplugged.com/tags/nh), [nix](https://linuxunplugged.com/tags/nix), [nix helper](https://linuxunplugged.com/tags/nix%20helper), [nixcon](https://linuxunplugged.com/tags/nixcon), [nixos](https://linuxunplugged.com/tags/nixos), [one simple rule](https://linuxunplugged.com/tags/one%20simple%20rule), [pinky's](https://linuxunplugged.com/tags/pinky's), [plasma](https://linuxunplugged.com/tags/plasma), [polkit](https://linuxunplugged.com/tags/polkit), [reactionary](https://linuxunplugged.com/tags/reactionary), [real-time audio](https://linuxunplugged.com/tags/real-time%20audio), [real-time kernel](https://linuxunplugged.com/tags/real-time%20kernel), [realplayer](https://linuxunplugged.com/tags/realplayer), [ryzen](https://linuxunplugged.com/tags/ryzen), [scipy](https://linuxunplugged.com/tags/scipy), [self meetup](https://linuxunplugged.com/tags/self%20meetup), [strategy tax](https://linuxunplugged.com/tags/strategy%20tax), [systemd devuan challenge](https://linuxunplugged.com/tags/systemd%20devuan%20challenge), [thinkpad](https://linuxunplugged.com/tags/thinkpad), [ublue aurora](https://linuxunplugged.com/tags/ublue%20aurora), [vscode](https://linuxunplugged.com/tags/vscode), [wayland](https://linuxunplugged.com/tags/wayland), [windows copilot](https://linuxunplugged.com/tags/windows%20copilot), [windows xp](https://linuxunplugged.com/tags/windows%20xp)

--- a/docs/linux-unplugged/2024/episode-565.md
+++ b/docs/linux-unplugged/2024/episode-565.md
@@ -1,0 +1,49 @@
+# LUP 565: Mistakes That Made Us Love Linux
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+NKs9X6M8?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-06-02
+* Duration: 83 mins 50 secs
+
+## About this episode
+
+The facepalm moments that make us question our sanity—and swear off sudo for a week.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://kolide.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Linux May Be the Best Way to Avoid the AI Nightmare](https://www.lifewire.com/install-linux-avoid-ai-8655664 "Linux May Be the Best Way to Avoid the AI Nightmare") — What if you care about AI's environmental impact, privacy holes, and the ethical problems of training on data without the creators' permission? The answer might be to switch to Linux. Yes, Linux.
+  * [Kate Asks about Mistakes to Avoid](https://paste.docs.lol/reader/TatterIcelanders "Kate Asks about Mistakes to Avoid") — Hey boys-Microsoft has officially gone off the deep end with this AI stuff. I'm pretty sure AI Clippy is pulling the strings behind the scenes. Any tips for escaping to Linux before I get assimilated? What are the big don'ts for a newbie?
+  * [Jeremy Molina on X](https://x.com/jeremymolina/status/1796595527108468849 "Jeremy Molina on X") — sudo rm -rf ./ on the root directory 😓
+  * [Lee Ball on X](https://x.com/lee_ball/status/1797260554513342701 "Lee Ball on X") — I thought I was in a backup directory when I did an rm -rf but turned out I'd forgotten the ./ and just went into /var/lib/mysql and not the backup of said directory.
+  * [ChaoticHuman on X](https://x.com/_ChaoticHuman/status/1796631702736863502 "ChaoticHuman on X") — I think my most major beginner mistake once was something like sudochownuseraccount/ because I wanted to not have to deal with file-ownership-conflicts though I no longer remember what exactly I did. I only remember that it led to completely destroying my Linux-system.
+  * [Ken Starks on X](https://x.com/Reglue/status/1796755606227112154 "Ken Starks on X") — What are all these files with a dot before them. They aren't programs. Might as well delete them.
+  * [PDunn on X](https://x.com/pwdunn/status/1796638182697521625 "PDunn on X") — Using fringe distos and too much distrohopping causing loss of time and not being productive. Linux can be a time sink I don't have time for. So I installed Ubuntu and moved on. I just use what works and is easy to maintain. Unplugged contributor here.
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [Chris' Beelink Nix Config](https://github.com/ChrisLAS/nix/blob/main/configuration.nix "Chris' Beelink Nix Config")
+  * [Nix from First Principles: Flake Edition](https://tonyfinn.com/blog/nix-from-first-principles-flake-edition/ "Nix from First Principles: Flake Edition") — This guide is a beginner's guide to Nix and related tooling, focusing on the newer nix command, and flake.nix compared to older tools like nix-env and default.nix. It does not require any prior Nix knowledge, and instead builds up the Flake based world from first principles, so that it can serve as an introduction to Nix itself, as well as the concept and uses of Flakes.
+  * [Pick: Delfin](https://delfin.avery.cafe/ "Pick: Delfin") — Delfin is a native client for the Jellyfin media server. It features a fast and clean interface to stream your media in an embedded MPV-based video player.
+  * [Delfin on Flathub](https://flathub.org/apps/cafe.avery.Delfin "Delfin on Flathub")
+  * [Delfin repo](https://codeberg.org/avery42/delfin "Delfin repo")
+  * [Delfin nix package](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/de/delfin/package.nix "Delfin nix package")
+  * [A fireside chat with Nextcloud founder Frank Karlitschek - Nextcloud](https://nextcloud.com/blog/a-fireside-chat-with-nextcloud-founder-frank-karlitschek/ "A fireside chat with Nextcloud founder Frank Karlitschek - Nextcloud") — Part of this talk was on LUP, now you can hear the full thing.
+
+
+
+## Tags
+
+[ai clippy](https://linuxunplugged.com/tags/ai%20clippy), [ai strategy tax](https://linuxunplugged.com/tags/ai%20strategy%20tax), [beelink](https://linuxunplugged.com/tags/beelink), [beginner mistakes](https://linuxunplugged.com/tags/beginner%20mistakes), [dd](https://linuxunplugged.com/tags/dd), [debian](https://linuxunplugged.com/tags/debian), [delfin](https://linuxunplugged.com/tags/delfin), [dependency hell](https://linuxunplugged.com/tags/dependency%20hell), [distrohopping](https://linuxunplugged.com/tags/distrohopping), [dotfiles](https://linuxunplugged.com/tags/dotfiles), [everyone makes mistakes](https://linuxunplugged.com/tags/everyone%20makes%20mistakes), [frank karlitschek](https://linuxunplugged.com/tags/frank%20karlitschek), [gnome 3](https://linuxunplugged.com/tags/gnome%203), [gobolinux](https://linuxunplugged.com/tags/gobolinux), [grub](https://linuxunplugged.com/tags/grub), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kate](https://linuxunplugged.com/tags/kate), [linux don'ts](https://linuxunplugged.com/tags/linux%20don'ts), [linux install mistakes](https://linuxunplugged.com/tags/linux%20install%20mistakes), [linux mistakes](https://linuxunplugged.com/tags/linux%20mistakes), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux refuge](https://linuxunplugged.com/tags/linux%20refuge), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [live-usb](https://linuxunplugged.com/tags/live-usb), [microsoft](https://linuxunplugged.com/tags/microsoft), [nextcloud](https://linuxunplugged.com/tags/nextcloud), [nine-fives](https://linuxunplugged.com/tags/nine-fives), [nixos](https://linuxunplugged.com/tags/nixos), [nvidia](https://linuxunplugged.com/tags/nvidia), [oom killer](https://linuxunplugged.com/tags/oom%20killer), [podverse](https://linuxunplugged.com/tags/podverse), [ssh updates](https://linuxunplugged.com/tags/ssh%20updates), [sudo rm -rf](https://linuxunplugged.com/tags/sudo%20rm%20-rf), [ubuntu](https://linuxunplugged.com/tags/ubuntu), [windows 8 moment](https://linuxunplugged.com/tags/windows%208%20moment), [zram](https://linuxunplugged.com/tags/zram), [🤦](https://linuxunplugged.com/tags/%F0%9F%A4%A6)

--- a/docs/linux-unplugged/2024/episode-566.md
+++ b/docs/linux-unplugged/2024/episode-566.md
@@ -1,0 +1,67 @@
+# LUP 566: Chef's Choice Ubuntu
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+yTUnhhj8?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-06-09
+* Duration: 92 mins 55 secs
+
+## About this episode
+
+We try Omakub, a new opinionated Ubuntu desktop for power users and macOS expats.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [Kolide](https://kolide.com/unplugged): [Kolide is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://kolide.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Have a pint with Alex in Norwich , Sun, Jun 16, 2024, 2:30 PM | Meetup](https://www.meetup.com/jupiterbroadcasting/events/301539637/ "Have a pint with Alex in Norwich , Sun, Jun 16, 2024, 2:30 PM | Meetup")
+  * [Spokane Meetup, Sat, Jul 13, 2024, 4:00 PM](https://www.meetup.com/jupiterbroadcasting/events/301471716/ "Spokane Meetup, Sat, Jul 13, 2024, 4:00 PM")
+  * [Nextcloud Conference 2024: call for speakers - Nextcloud](https://nextcloud.com/blog/nextcloud-conference-2024-call-for-speakers/ "Nextcloud Conference 2024: call for speakers - Nextcloud")
+  * [Nextcloud Conference 2024 - Nextcloud](https://nextcloud.com/conference-2024/ "Nextcloud Conference 2024 - Nextcloud")
+  * [Berlin with Brent: September Meetup @ Nextcloud Conference, Fri, Sep 13, 2024 | Meetup](https://www.meetup.com/jupiterbroadcasting/events/300421391/ "Berlin with Brent: September Meetup @ Nextcloud Conference, Fri, Sep 13, 2024 | Meetup")
+  * [notch on X](https://x.com/notch/status/1799518748388299209 "notch on X") — Alright, that's enough spyware in my OS. Do I go desktop Mac, or do I have the energy to go full Linux? Not sure, but I'm tired of my operating system treating me like the product.
+  * [DHH on X](https://x.com/dhh/status/1798772064872223118 "DHH on X") — If I have such a fundamental misalignment with where Apple has gone, why stay? I think that was the question I finally just asked myself for the umph-teenth time, and realized I didn’t have a good answer that wasn’t just based on comfort.
+  * [For the Love of Linux](https://37signals.com/podcast/for-the-love-of-linux/ "For the Love of Linux") — In this podcast episode, REWORK host Kimberly Rhodes talks with David Heinemeier Hansson, co-founder of 37signals and CTO, about his personal shift from using Apple products to exploring Linux and Windows platforms. He discusses the expanded platform integration at 37signals, which now includes all three operating systems.
+  * [DHH on X](https://x.com/dhh/status/1798640367480553582 "DHH on X") — The big YearofLinuxontheDesktop will be 2025. Snapdragon X chips will be ready. Folks will be sick of AI shoved into every crevasse of their life. Thank heaven for disagreeable nerds refusing to bend the knee to the corporate agenda!
+  * [Linux as the new developer default at 37signals](https://world.hey.com/dhh/linux-as-the-new-developer-default-at-37signals-ef0823b7 "Linux as the new developer default at 37signals") — I've personally been having a blast over the last few months digging deeper and deeper into the Linux rabbit hole, and it's been a delight discovering just how good its become as developer platform.
+  * [Introducing Omakub](https://world.hey.com/dhh/introducing-omakub-354db366 "Introducing Omakub") — Omakub turns a fresh Ubuntu installation into a fully-configured, beautiful, and modern web development system by running a single command.
+  * [Xournal++](https://xournalpp.github.io/ "Xournal++")
+  * [Flameshot](https://flameshot.org/ "Flameshot")
+  * [Pinta](https://www.pinta-project.com/ "Pinta")
+  * [Framework](https://frame.work/ "Framework")
+  * [Omakub list of installed apps](https://github.com/basecamp/omakub/tree/master/install "Omakub list of installed apps")
+  * [Omakub](https://omakub.org/ "Omakub") — An Omakase Developer Setup for Ubuntu 24.04 by DHH
+  * [Omakub on GitHub](https://github.com/basecamp/omakub "Omakub on GitHub")
+  * [Omakub introductory video](https://www.youtube.com/watch?v=aXLra-31Jh0 "Omakub introductory video")
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [devenv](https://devenv.sh/ "devenv") — Fast, Declarative, Reproducible and Composable Developer Environments using Nix
+  * [squid](https://www.squid-cache.org/ "squid")
+  * [GeneBean on X](https://x.com/technicalissues/status/1510740301140443140 "GeneBean on X") — My dad was so happy with his desktop after I switched him to #Pop_OS! that he had me do the same to the laptop he takes on trips. Thanks for such a stellar distro @system76
+  * [Walkthrough of Nix Install and Setup on MacOS by zmre on YouTube](https://youtu.be/LE5JR4JcvMg?si=HsZvsyXczmaPmTEm "Walkthrough of Nix Install and Setup on MacOS by zmre on YouTube")
+  * [Wildspaces.work](https://www.wildspaces.work/ "Wildspaces.work") — Wildpsaces.work is designed for remote workers interested in reconnecting with community and working from new and wild places.
+  * [Chris' Amazon Tablet](https://www.amazon.com/gp/product/B0CHY4QR46/ref=ppx_yo_dt_b_search_asin_title?ie=UTF8&th=1 "Chris' Amazon Tablet") — 10.1 Inch Android 13 Octa-core with 8(4+4) GB+128GB Tablets, 5MP+8MP Camera, Bluetooth 5.0
+  * [Fully Kiosk Browser Lockdown](https://www.fully-kiosk.com/ "Fully Kiosk Browser Lockdown")
+  * [Jellyfin Media Player](https://github.com/jellyfin/jellyfin-media-player "Jellyfin Media Player") — Desktop client using jellyfin-web with embedded MPV player. Supports Windows, Mac OS, and Linux.
+  * [kthresher: Tool to remove unused kernels in Debian/Ubuntu](https://github.com/rackerlabs/kthresher "kthresher: Tool to remove unused kernels in Debian/Ubuntu")
+  * [helipad-flake](https://github.com/noblepayne/helipad-flake "helipad-flake") — A Nix flake to provide a helipad package and NixOS module. Intended for use with nix-bitcoin.
+  * [Kopia](https://kopia.io/ "Kopia") — Fast and Secure Open-Source Backup Software
+  * [Pick: Multiplex](https://flathub.org/apps/com.pojtinger.felicitas.Multiplex "Pick: Multiplex") — Multiplex is an app to watch torrents together, providing an experience similar to Apple's SharePlay and Amazon's Prime Video Watch Party.
+  * [weron](https://github.com/pojntfx/weron "weron") — weron provides lean, fast & secure overlay networks based on WebRTC.
+
+
+
+## Tags
+
+[.net](https://linuxunplugged.com/tags/.net), [37signals](https://linuxunplugged.com/tags/37signals), [alacritty](https://linuxunplugged.com/tags/alacritty), [apple](https://linuxunplugged.com/tags/apple), [babylon 5](https://linuxunplugged.com/tags/babylon%205), [backups](https://linuxunplugged.com/tags/backups), [backwoods setup](https://linuxunplugged.com/tags/backwoods%20setup), [bash](https://linuxunplugged.com/tags/bash), [chef's choice](https://linuxunplugged.com/tags/chef's%20choice), [configuration](https://linuxunplugged.com/tags/configuration), [customizability](https://linuxunplugged.com/tags/customizability), [david heinemeier hansson](https://linuxunplugged.com/tags/david%20heinemeier%20hansson), [deb packages](https://linuxunplugged.com/tags/deb%20packages), [desktop stability](https://linuxunplugged.com/tags/desktop%20stability), [desktop themes](https://linuxunplugged.com/tags/desktop%20themes), [dev workstation](https://linuxunplugged.com/tags/dev%20workstation), [developer environment](https://linuxunplugged.com/tags/developer%20environment), [developer setup](https://linuxunplugged.com/tags/developer%20setup), [devenv](https://linuxunplugged.com/tags/devenv), [dhh](https://linuxunplugged.com/tags/dhh), [docker](https://linuxunplugged.com/tags/docker), [dotfiles](https://linuxunplugged.com/tags/dotfiles), [extensibility](https://linuxunplugged.com/tags/extensibility), [flameshot](https://linuxunplugged.com/tags/flameshot), [flatpak](https://linuxunplugged.com/tags/flatpak), [fully kiosk browser](https://linuxunplugged.com/tags/fully%20kiosk%20browser), [gnome](https://linuxunplugged.com/tags/gnome), [jellyfin media player](https://linuxunplugged.com/tags/jellyfin%20media%20player), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [keyboard-first workflow](https://linuxunplugged.com/tags/keyboard-first%20workflow), [kopia](https://linuxunplugged.com/tags/kopia), [kthresher](https://linuxunplugged.com/tags/kthresher), [lazydocker](https://linuxunplugged.com/tags/lazydocker), [lazyvim](https://linuxunplugged.com/tags/lazyvim), [linux mistakes](https://linuxunplugged.com/tags/linux%20mistakes), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [linux workstation bootstrapping](https://linuxunplugged.com/tags/linux%20workstation%20bootstrapping), [linux's slow burn](https://linuxunplugged.com/tags/linux's%20slow%20burn), [lts](https://linuxunplugged.com/tags/lts), [macos](https://linuxunplugged.com/tags/macos), [mate](https://linuxunplugged.com/tags/mate), [mise](https://linuxunplugged.com/tags/mise), [multiplex](https://linuxunplugged.com/tags/multiplex), [neovim](https://linuxunplugged.com/tags/neovim), [nix](https://linuxunplugged.com/tags/nix), [nix drinking game](https://linuxunplugged.com/tags/nix%20drinking%20game), [nixos](https://linuxunplugged.com/tags/nixos), [notch](https://linuxunplugged.com/tags/notch), [omakase](https://linuxunplugged.com/tags/omakase), [omakase spirit](https://linuxunplugged.com/tags/omakase%20spirit), [omakub](https://linuxunplugged.com/tags/omakub), [opinionated setup](https://linuxunplugged.com/tags/opinionated%20setup), [overlay network](https://linuxunplugged.com/tags/overlay%20network), [pop!_os](https://linuxunplugged.com/tags/pop!_os), [ppa](https://linuxunplugged.com/tags/ppa), [setup script](https://linuxunplugged.com/tags/setup%20script), [shareplay](https://linuxunplugged.com/tags/shareplay), [squid proxy](https://linuxunplugged.com/tags/squid%20proxy), [syncplay](https://linuxunplugged.com/tags/syncplay), [tactile extension](https://linuxunplugged.com/tags/tactile%20extension), [tokyo night](https://linuxunplugged.com/tags/tokyo%20night), [torrents](https://linuxunplugged.com/tags/torrents), [ubuntu](https://linuxunplugged.com/tags/ubuntu), [ubuntu 24.04](https://linuxunplugged.com/tags/ubuntu%2024.04), [ulauncher](https://linuxunplugged.com/tags/ulauncher), [vscode](https://linuxunplugged.com/tags/vscode), [watch party](https://linuxunplugged.com/tags/watch%20party), [watch together](https://linuxunplugged.com/tags/watch%20together), [webrtc](https://linuxunplugged.com/tags/webrtc), [weron](https://linuxunplugged.com/tags/weron), [window tiling](https://linuxunplugged.com/tags/window%20tiling), [windows](https://linuxunplugged.com/tags/windows), [wsl](https://linuxunplugged.com/tags/wsl), [xournal++](https://linuxunplugged.com/tags/xournal++), [zellij](https://linuxunplugged.com/tags/zellij)

--- a/docs/linux-unplugged/2024/episode-567.md
+++ b/docs/linux-unplugged/2024/episode-567.md
@@ -1,0 +1,66 @@
+# LUP 567: So Long sudo
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+3R9Ckl8O?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-06-16
+* Duration: 91 mins 41 secs
+
+## About this episode
+
+Your Linux box is a-changin'. systemd has a huge new release; we'll get into the most impressive features, including the new sudo replacement. Plus, our thoughts on the new Linux Arm laptops that are just around the corner.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Announcing systemd v256](https://0pointer.net/blog/announcing-systemd-v256.html "Announcing systemd v256") — In the weeks leading up to this release I have posted a series of serieses of posts to Mastodon about key new features in this release.
+  * [systemd changes with v2⁸:](https://github.com/systemd/systemd/releases/tag/v256 "systemd changes with v2⁸:")
+  * [systemd 256 Released With run0, systemd-vpick, importctl & Other New Features](https://www.phoronix.com/news/systemd-256 "systemd 256 Released With run0, systemd-vpick, importctl & Other New Features")
+  * [Lennart on systemd-vpick](https://mastodon.social/@pid_eins/112332457438509644 "Lennart on systemd-vpick") — Basically, you can now place multiple versions of the same resource in some dir of your choice, suffix that dir's name with .v/ and the you get some basic version management in place: delete or add new versions by just removing/adding new files, and the tools will find the newest item dropped in automatically.
+  * [Introduction to Portable Services](https://systemd.io/PORTABLE_SERVICES/ "Introduction to Portable Services") — “Portable services” do not provide a fully isolated environment to the payload, like containers mostly intend to. Instead, they are more like regular system services, can be controlled with the same tools, are exposed the same way in all infrastructure, and so on. The main difference is that they use a different root directory than the rest of the system.
+  * [Trying out systemd's Portable Services](https://samthursfield.wordpress.com/2022/05/13/trying-out-systemds-portable-services/ "Trying out systemd's Portable Services") — All in all, the core pieces are already in place for a very promising new technology that should make it easier for 3rd parties to provide Linux system-level software in a safe and convenient way, well done to the systemd team for a well executed concept. All it lacks is some polish around the tooling and integration.
+  * [systemd sleep](https://mastodon.social/@pid_eins/112404050701925757 "systemd sleep") — Putting a PC to sleep is complicated business and there are different mechanisms available to achieve this on Linux. 
+  * [Lennart on SSH and AF_VSOCK](https://mastodon.social/@pid_eins/112411213727666482 "Lennart on SSH and AF_VSOCK") — This automatic ssh-via-AF_VSOCK logic is particularly useful 
+  * [DDIs and systemd-nspawn](https://mastodon.social/@pid_eins/112364314961758625 "DDIs and systemd-nspawn") — Or in other words: there's now unprivileged systemd-npsawn containers. Yay!
+  * [Lennart on systemd-vmspawn](https://mastodon.social/@pid_eins/112376110947253007 "Lennart on systemd-vmspawn")
+  * [Lennart on sd_notify](https://mastodon.social/@pid_eins/112341584011845948 "Lennart on sd_notify")
+  * [Lennart on dlopen](https://mastodon.social/@pid_eins/112445409388762154 "Lennart on dlopen")
+  * [Lennart on run0](https://mastodon.social/@pid_eins/112353324518585654 "Lennart on run0") — There's a new tool in systemd, called run0. Or actually, it's not a new tool, it's actually the long existing tool systemd-run, but when invoked under the run0 name (via a symlink) it behaves a lot like a sudo clone. But with one key difference: it's not in fact SUID.
+  * [doas - dedicated openbsd application subexecutor](https://flak.tedunangst.com/post/doas "doas - dedicated openbsd application subexecutor")
+  * [Doas - NixOS Wiki](https://nixos.wiki/wiki/Doas "Doas - NixOS Wiki")
+  * [Doas on Wikipedia](https://en.wikipedia.org/wiki/Doas "Doas on Wikipedia")
+  * [The Tragedy of systemd](https://www.youtube.com/watch?v=o_AIw9bGogo "The Tragedy of systemd") — Join me on a journey through the bootstrap process, the history of init, the reasons why change can be scary, and the discovery of a part of your OS you may not even know existed.
+  * [The Two Year Journey Funded By Arm/Qualcomm For Improving ARM Linux Laptop Support](https://www.phoronix.com/news/Two-Years-Improving-ARM-Laptops "The Two Year Journey Funded By Arm/Qualcomm For Improving ARM Linux Laptop Support") — ARM Kernel developers spent the last two years working on improving ARM Linux laptop support with a focus on the Lenovo ThinkPad X13s powered by a Qualcomm SoC.
+  * [Ubuntu 24.04 LTS support to the Lenovo ThinkPad x13s](https://www.omgubuntu.co.uk/2024/05/ubuntu-24-04-lenovo-thinkpad-x13s-snapdragon "Ubuntu 24.04 LTS support to the Lenovo ThinkPad x13s")
+  * [Snapdragon 8cx](https://www.qualcomm.com/products/mobile/snapdragon/pcs-and-tablets/snapdragon-mobile-compute-platforms/snapdragon-8cx-gen-3-compute-platform "Snapdragon 8cx")
+  * [Ubuntu Asahi project](https://www.omgubuntu.co.uk/2023/10/ubuntu-ashai-for-apple-silicon "Ubuntu Asahi project")
+  * [TUXEDO Working on Snapdragon X Elite Linux Laptop](https://www.omgubuntu.co.uk/2024/06/tuxedo-working-on-snapdragon-x-elite-linux-laptop "TUXEDO Working on Snapdragon X Elite Linux Laptop")
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [Spokane Meetup, Sat, Jul 13, 2024, 4:00 PM](https://www.meetup.com/jupiterbroadcasting/events/301471716/ "Spokane Meetup, Sat, Jul 13, 2024, 4:00 PM")
+  * [Berlin with Brent: September Meetup @ Nextcloud Conference, Fri, Sep 13, 2024 | Meetup](https://www.meetup.com/jupiterbroadcasting/events/300421391/ "Berlin with Brent: September Meetup @ Nextcloud Conference, Fri, Sep 13, 2024 | Meetup")
+  * [A Nix Flake for Bitfocus Companion](https://github.com/noblepayne/bitfocus-companion-flake "A Nix Flake for Bitfocus Companion")
+  * [ChrisLAS' Beelink NixOS Config](https://github.com/ChrisLAS/nix "ChrisLAS' Beelink NixOS Config")
+  * [Bluetooth - NixOS Wiki](https://nixos.wiki/wiki/Bluetooth "Bluetooth - NixOS Wiki")
+  * [nix-direnv](https://determinate.systems/posts/nix-direnv/ "nix-direnv")
+  * [xscreensaver on Android](https://www.jwz.org/xscreensaver/google.html "xscreensaver on Android")
+  * [Rainier cherry - Wikipedia](https://en.wikipedia.org/wiki/Rainier_cherry "Rainier cherry - Wikipedia")
+  * [Pick: Iotas](https://gitlab.gnome.org/World/iotas "Pick: Iotas") — Markdown notes that syncs with NextCloud Notes.
+
+
+
+## Tags
+
+[256](https://linuxunplugged.com/tags/256), [arm](https://linuxunplugged.com/tags/arm), [beelink](https://linuxunplugged.com/tags/beelink), [berlin meetup](https://linuxunplugged.com/tags/berlin%20meetup), [berlin with brent](https://linuxunplugged.com/tags/berlin%20with%20brent), [bitfocus companion](https://linuxunplugged.com/tags/bitfocus%20companion), [cgroups](https://linuxunplugged.com/tags/cgroups), [doas](https://linuxunplugged.com/tags/doas), [father's day](https://linuxunplugged.com/tags/father's%20day), [homed-managed](https://linuxunplugged.com/tags/homed-managed), [importctl](https://linuxunplugged.com/tags/importctl), [iotas](https://linuxunplugged.com/tags/iotas), [ipod](https://linuxunplugged.com/tags/ipod), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [lenovo thinkpad x13s](https://linuxunplugged.com/tags/lenovo%20thinkpad%20x13s), [liblzma](https://linuxunplugged.com/tags/liblzma), [linux arm](https://linuxunplugged.com/tags/linux%20arm), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [nextcloud conference](https://linuxunplugged.com/tags/nextcloud%20conference), [nextcloud notes](https://linuxunplugged.com/tags/nextcloud%20notes), [nix drinking game](https://linuxunplugged.com/tags/nix%20drinking%20game), [nix-darwin](https://linuxunplugged.com/tags/nix-darwin), [nix-direnv](https://linuxunplugged.com/tags/nix-direnv), [norwich meetup](https://linuxunplugged.com/tags/norwich%20meetup), [ntp challenge](https://linuxunplugged.com/tags/ntp%20challenge), [omakub](https://linuxunplugged.com/tags/omakub), [portable service](https://linuxunplugged.com/tags/portable%20service), [qualcomm](https://linuxunplugged.com/tags/qualcomm), [rockbox os](https://linuxunplugged.com/tags/rockbox%20os), [run0](https://linuxunplugged.com/tags/run0), [snapdragon](https://linuxunplugged.com/tags/snapdragon), [spokane meetup](https://linuxunplugged.com/tags/spokane%20meetup), [squid](https://linuxunplugged.com/tags/squid), [ssh](https://linuxunplugged.com/tags/ssh), [sudo](https://linuxunplugged.com/tags/sudo), [suid](https://linuxunplugged.com/tags/suid), [system v](https://linuxunplugged.com/tags/system%20v), [systemd](https://linuxunplugged.com/tags/systemd), [systemd sleep](https://linuxunplugged.com/tags/systemd%20sleep), [systemd-nspawn](https://linuxunplugged.com/tags/systemd-nspawn), [systemd-run0](https://linuxunplugged.com/tags/systemd-run0), [systemd-vmspawn](https://linuxunplugged.com/tags/systemd-vmspawn), [systemd-vpick](https://linuxunplugged.com/tags/systemd-vpick), [the tragedy of systemd](https://linuxunplugged.com/tags/the%20tragedy%20of%20systemd), [ubuntu](https://linuxunplugged.com/tags/ubuntu), [v2⁸](https://linuxunplugged.com/tags/v2%E2%81%B8), [xscreensaver for android](https://linuxunplugged.com/tags/xscreensaver%20for%20android), [xz](https://linuxunplugged.com/tags/xz)

--- a/docs/linux-unplugged/2024/episode-568.md
+++ b/docs/linux-unplugged/2024/episode-568.md
@@ -1,0 +1,76 @@
+# LUP 568: All Your Silos are Broken
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+QvHYYuJN?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-06-23
+* Duration: 81 mins 3 secs
+
+## About this episode
+
+Online identity is a ticking time bomb. Are trustworthy, open-source solutions ready to disarm it? Or will we be stuck with lackluster, proprietary systems?
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Jupiter Broadcasting Meetups](https://www.meetup.com/jupiterbroadcasting/ "Jupiter Broadcasting Meetups")
+  * [XZ Utils Backdoor Vulnerability (CVE-2024-3094): Comprehensive Guide](https://www.uptycs.com/blog/xz-utils-backdoor-vulnerability-cve-2024-3094 "XZ Utils Backdoor Vulnerability \(CVE-2024-3094\): Comprehensive Guide")
+  * [The Mystery of ‘Jia Tan,’ the XZ Backdoor Mastermind](https://www.wired.com/story/jia-tan-xz-backdoor/ "The Mystery of ‘Jia Tan,’ the XZ Backdoor Mastermind")
+  * [Who is ‘Jia Tan,’ the coder behind the XZ Utils Linux backdoor?](https://www.theverge.com/2024/4/3/24120244/who-is-jia-tan-the-coder-behind-the-xz-utils-linux-backdoor "Who is ‘Jia Tan,’ the coder behind the XZ Utils Linux backdoor?")
+  * [Reflections on Distrusting xz](https://news.ycombinator.com/item?id=39914981 "Reflections on Distrusting xz")
+  * [The Linux kernel does not accept anonymous contributions due to legal reasons.](https://news.ycombinator.com/item?id=17487801 "The Linux kernel does not accept anonymous contributions due to legal reasons.") — The Linux kernel does not accept anonymous contributions due to legal reasons.
+  * [Kernel.org Docs on contributions](https://www.kernel.org/doc/html/latest/process/1.Intro.html "Kernel.org Docs on contributions") — It is imperative that all code contributed to the kernel be legitimately free software.
+  * [Elon Musk wants to ‘authenticate all real humans’ on Twitter.](https://www.cnn.com/2022/04/28/tech/elon-musk-authenticate-all-real-humans/index.html "Elon Musk wants to ‘authenticate all real humans’ on Twitter.")
+  * [Elon Musk claims alien identity, links human brain function to AI purpose](https://www.livemint.com/technology/tech-news/elon-musk-claims-alien-identity-links-human-brain-function-to-ai-purpose-11716714971682.html "Elon Musk claims alien identity, links human brain function to AI purpose")
+  * [Elon Musk Finally Realizes That Verification Requires More Than A Credit Card, Planning To Make Users Upload Gov’t ID](https://www.techdirt.com/2023/08/22/elon-musk-finally-realizes-that-verification-requires-more-than-a-credit-card-planning-to-make-users-upload-govt-id/ "Elon Musk Finally Realizes That Verification Requires More Than A Credit Card, Planning To Make Users Upload Gov’t ID")
+  * [Elon Musk can show the world how to really do ID](https://www.businessage.com/post/elon-musk-can-show-the-world-how-to-really-do-id "Elon Musk can show the world how to really do ID")
+  * [World ID](https://worldcoin.org/world-id "World ID")
+  * [Nostr: All Your Silos Are Broken](https://www.youtube.com/watch?v=SSFVR5ZXOuA "Nostr: All Your Silos Are Broken")
+  * [Nostr Iceberg Meme](https://miro.medium.com/v2/resize:fit:720/format:webp/0*Vq5EjPTk28SBl7Fn.jpeg "Nostr Iceberg Meme")
+  * [NIP-01](https://github.com/nostr-protocol/nips/blob/master/01.md "NIP-01")
+  * [Mapping Nostr keys to DNS-based internet identifiers](https://github.com/nostr-protocol/nips/blob/master/05.md "Mapping Nostr keys to DNS-based internet identifiers")
+  * [Navigating the social graph](https://pippellia.com/pippellia/Social+Graph/Navigating+the+social+graph "Navigating the social graph") — In this paper, you will find a definition of the social graph, principles for thinking about it, and practical ideas for using it for DoS prevention, social discovery, anti-impersonation, accurate ratings, and more.
+  * [Highlighter](http://highlighter.com/ "Highlighter") — Highlighter is like Substack & Patreon but on Nostr.
+  * [Satlantis](http://satlantis.io/ "Satlantis") — Satlantis is like Trip Advisor, meets Instagram and Google Places.
+  * [HiveTalk](https://hivetalk.org/ "HiveTalk") — Free Video Calls, Messaging and Screen Sharing
+  * [zap.stream](https://zap.stream/ "zap.stream") — Twitch alt powered by value for value and Nostr
+  * [ostrGit](https://github.com/NostrGit/NostrGit "ostrGit") — A truly censorship-resistant alternative to GitHub that has a chance of working.
+  * [Blogstack](https://blogstack.io/ "Blogstack") — Write decentralized blogs over relay using nostr w/ ⚡ lightning tips.
+  * [Ditto](https://soapbox.pub/blog/announcing-ditto/ "Ditto") — Ditto is a Nostr community server. It has a built-in Nostr relay, a web UI, and it implements Mastodon's REST API.
+  * [UseNostr](https://usenostr.org/ "UseNostr")
+  * [awesome-nostr](https://github.com/aljazceru/awesome-nostr "awesome-nostr")
+  * [Decentralized publishing for the web](https://nostr.how/en/what-is-nostr "Decentralized publishing for the web")
+  * [Nostr Apps](https://www.nostrapps.com/ "Nostr Apps")
+  * [Nosta](https://nosta.me/ "Nosta") — New to Nostr? You're in the right place. Here you can easily set up your profile, discover apps, and browse other profiles.
+  * [Amethyst](https://www.nostrapps.com/apps/amethyst "Amethyst")
+  * [amethyst: Nostr client for Android](https://github.com/vitorpamplona/amethyst "amethyst: Nostr client for Android")
+  * [yana](https://github.com/frnandu/yana "yana")
+  * [Primal App](https://primal.net/downloads "Primal App")
+  * [Dan's Nostr Relay](wss://nostr.strits.dk "Dan's Nostr Relay")
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [SpeechNote](https://flathub.org/apps/net.mkiol.SpeechNote "SpeechNote") — Speech Note let you take, read and translate notes in multiple languages. It uses Speech to Text, Text to Speech and Machine Translation to do so.
+  * [rhasspy/piper:](https://github.com/rhasspy/piper "rhasspy/piper:") — A fast, local neural text to speech system.
+  * [Starship](https://starship.rs/ "Starship") — The minimal, blazing-fast, and infinitely customizable prompt for any shell!
+  * [starship on GitHub](https://github.com/starship/starship "starship on GitHub")
+  * [ZSH Docs: ZDOTDIR](https://zsh-manual.netlify.app/files?highlight=ZDOTDIR#51-startupshutdown-files "ZSH Docs: ZDOTDIR")
+  * [distrobox-assemble](https://github.com/89luca89/distrobox/blob/main/docs/usage/distrobox-assemble.md "distrobox-assemble") — distrobox-assemble takes care of creating or destroying containers in batches, based on a manifest file.
+  * [Pick: Gathio](https://gath.io/ "Pick: Gathio") — Gathio is a simple, federated, privacy-first event hosting platform.
+
+
+
+## Tags
+
+[amethyst](https://linuxunplugged.com/tags/amethyst), [awesome-nostr](https://linuxunplugged.com/tags/awesome-nostr), [blogstack](https://linuxunplugged.com/tags/blogstack), [btc prague](https://linuxunplugged.com/tags/btc%20prague), [commercial identity](https://linuxunplugged.com/tags/commercial%20identity), [cryptography](https://linuxunplugged.com/tags/cryptography), [decentralized web](https://linuxunplugged.com/tags/decentralized%20web), [distrobox](https://linuxunplugged.com/tags/distrobox), [distrobox-assemble](https://linuxunplugged.com/tags/distrobox-assemble), [ditto](https://linuxunplugged.com/tags/ditto), [gathio](https://linuxunplugged.com/tags/gathio), [gnupg](https://linuxunplugged.com/tags/gnupg), [highlighter](https://linuxunplugged.com/tags/highlighter), [hivetalk](https://linuxunplugged.com/tags/hivetalk), [id](https://linuxunplugged.com/tags/id), [jia tan](https://linuxunplugged.com/tags/jia%20tan), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [ladybird](https://linuxunplugged.com/tags/ladybird), [lightning](https://linuxunplugged.com/tags/lightning), [linux kernel](https://linuxunplugged.com/tags/linux%20kernel), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [nips](https://linuxunplugged.com/tags/nips), [nix drinking game](https://linuxunplugged.com/tags/nix%20drinking%20game), [nixos](https://linuxunplugged.com/tags/nixos), [nosta](https://linuxunplugged.com/tags/nosta), [nostr](https://linuxunplugged.com/tags/nostr), [nostr nook](https://linuxunplugged.com/tags/nostr%20nook), [notes and other stuff transmitted by relays](https://linuxunplugged.com/tags/notes%20and%20other%20stuff%20transmitted%20by%20relays), [open source zealot](https://linuxunplugged.com/tags/open%20source%20zealot), [openpgp](https://linuxunplugged.com/tags/openpgp), [ostrgit](https://linuxunplugged.com/tags/ostrgit), [pgp](https://linuxunplugged.com/tags/pgp), [piper](https://linuxunplugged.com/tags/piper), [primal](https://linuxunplugged.com/tags/primal), [relays](https://linuxunplugged.com/tags/relays), [relevance glue](https://linuxunplugged.com/tags/relevance%20glue), [satlantis](https://linuxunplugged.com/tags/satlantis), [squid](https://linuxunplugged.com/tags/squid), [starship](https://linuxunplugged.com/tags/starship), [stirling-pdf](https://linuxunplugged.com/tags/stirling-pdf), [sudo flame war](https://linuxunplugged.com/tags/sudo%20flame%20war), [systemd](https://linuxunplugged.com/tags/systemd), [systemd run0](https://linuxunplugged.com/tags/systemd%20run0), [text to speech](https://linuxunplugged.com/tags/text%20to%20speech), [tts](https://linuxunplugged.com/tags/tts), [web of trust](https://linuxunplugged.com/tags/web%20of%20trust), [wikifreedia](https://linuxunplugged.com/tags/wikifreedia), [world coin](https://linuxunplugged.com/tags/world%20coin), [xz](https://linuxunplugged.com/tags/xz), [xz backdoor](https://linuxunplugged.com/tags/xz%20backdoor), [xz utils](https://linuxunplugged.com/tags/xz%20utils), [yana](https://linuxunplugged.com/tags/yana), [zap.stream](https://linuxunplugged.com/tags/zap.stream), [zsh](https://linuxunplugged.com/tags/zsh), [⚡](https://linuxunplugged.com/tags/%E2%9A%A1)

--- a/docs/linux-unplugged/2024/episode-569.md
+++ b/docs/linux-unplugged/2024/episode-569.md
@@ -1,0 +1,58 @@
+# LUP 569: Our Plasma Panacea
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+3lRpgX-a?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-06-30
+* Duration: 66 mins 51 secs
+
+## About this episode
+
+Why we think Plasma 6.1 is the desktop for people who like to mess with computers.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Marknote - KDE Applications](https://apps.kde.org/marknote/ "Marknote - KDE Applications")
+  * [Marknote 1.3 - KDE Blogs](https://blogs.kde.org/2024/06/28/marknote-1.3/ "Marknote 1.3 - KDE Blogs") — Marknote lets you create rich text notes and easily organise them into notebooks. You can personalise your notebooks by choosing an icon and accent color for each one, making it easy to distinguish between them and keep your notes at your fingertips. Your notes are saved as Markdown files in your Documents folder, making it easy to use your notes outside of Marknote as well as inside the app.
+  * [Spokane Meetup - No-Li Brewhouse, Sat, Jul 13, 2024, 4:00 PM](https://www.meetup.com/jupiterbroadcasting/events/301471716/?slug=jupiterbroadcasting&eventId=301471716 "Spokane Meetup - No-Li Brewhouse, Sat, Jul 13, 2024, 4:00 PM")
+  * [No-Li Brewhouse Menu](https://www.nolibrewhouse.com/brewhouse "No-Li Brewhouse Menu")
+  * [10 best beer gardens in the US where you can quench your thirst](https://10best.usatoday.com/awards/travel/best-beer-garden-2024/ "10 best beer gardens in the US where you can quench your thirst")
+  * [KDE Plasma 6.1 Desktop Environment Officially Released, Here's What's New](https://9to5linux.com/kde-plasma-6-1-desktop-environment-officially-released-heres-whats-new "KDE Plasma 6.1 Desktop Environment Officially Released, Here's What's New")
+  * [Plasma 6.1 - KDE Community](https://kde.org/announcements/plasma/6/6.1.0/ "Plasma 6.1 - KDE Community") — This release introduces explicit GPU synchronization support for NVIDIA users and triple buffering support on Wayland for smoother animations.
+  * [KDE Plasma 6.1.1 Desktop Environment Released with Various Bug Fixes](https://9to5linux.com/kde-plasma-6-1-1-desktop-environment-released-with-various-bug-fixes "KDE Plasma 6.1.1 Desktop Environment Released with Various Bug Fixes")
+  * [LUP 552](https://linuxunplugged.com/552 "LUP 552") — Plasma 6 is out, and we've been giving it a go. What's new, our thoughts, and the lessons other desktops should learn.
+  * [KDE Plasma 6.1 Performing Much Better On Older Intel Integrated Graphics](https://www.phoronix.com/news/KDE-Plasma-6.1-Intel-iGPU "KDE Plasma 6.1 Performing Much Better On Older Intel Integrated Graphics")
+  * [Fixing KWin's performance on old hardware](https://zamundaaa.github.io/wayland/2024/06/25/fixing-kwin-perf-on-old-hardware.html "Fixing KWin's performance on old hardware")
+  * [plasma6-desktop package versions](https://repology.org/project/plasma6-desktop/versions "plasma6-desktop package versions")
+  * [plasma-desktop package versions](https://repology.org/project/plasma-desktop/versions "plasma-desktop package versions")
+  * [KRdp on GitLab](https://invent.kde.org/plasma/krdp "KRdp on GitLab") — Currently, the main client that has been used for testing and is confirmed to work is the FreeRDP client.
+  * [Open KRdp Bugs](https://bugs.kde.org/buglist.cgi?component=general&list_id=2751390&product=KRdp&resolution=--- "Open KRdp Bugs")
+  * [appiumtests: test adaptive panel opacity (!2324) · Merge requests · Plasma / Plasma Desktop · GitLab](https://invent.kde.org/plasma/plasma-desktop/-/merge_requests/2324 "appiumtests: test adaptive panel opacity \(!2324\) · Merge requests · Plasma / Plasma Desktop · GitLab")
+  * [Why the next GNOME Release will be one of the Best Ever](https://www.reddit.com/r/gnome/comments/1dr66ud/why_the_next_gnome_release_will_be_one_of_the/ "Why the next GNOME Release will be one of the Best Ever")
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [Gathio](https://gath.io/ "Gathio")
+  * [JB Events Gathio hosted by HybridSarcasm](https://jbevents.hybridsarcasm.xyz/events/ "JB Events Gathio hosted by HybridSarcasm")
+  * [GitHub Issue: Can't create events](https://github.com/lowercasename/gathio/issues/150 "GitHub Issue: Can't create events") — An unexpected error has occurred. Please try again later.
+  * [Crossover: Run Microsoft Windows software on Mac and Linux | CodeWeavers](https://www.codeweavers.com/crossover "Crossover: Run Microsoft Windows software on Mac and Linux | CodeWeavers")
+  * [FUTO Keyboard](https://keyboard.futo.org/ "FUTO Keyboard") — Your keyboard shouldn't connect to the internet.
+  * [FUTO Keyboard · Wiki](https://gitlab.futo.org/alex/keyboard-wiki/-/wikis/FUTO-Keyboard "FUTO Keyboard · Wiki")
+
+
+
+## Tags
+
+[crossover](https://linuxunplugged.com/tags/crossover), [flatpak](https://linuxunplugged.com/tags/flatpak), [freerdp](https://linuxunplugged.com/tags/freerdp), [futo keyboard](https://linuxunplugged.com/tags/futo%20keyboard), [gathio](https://linuxunplugged.com/tags/gathio), [gnome](https://linuxunplugged.com/tags/gnome), [grapheneos](https://linuxunplugged.com/tags/grapheneos), [headscale](https://linuxunplugged.com/tags/headscale), [house-to-house lasers](https://linuxunplugged.com/tags/house-to-house%20lasers), [intel integrated graphics](https://linuxunplugged.com/tags/intel%20integrated%20graphics), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kde](https://linuxunplugged.com/tags/kde), [kde plasma](https://linuxunplugged.com/tags/kde%20plasma), [krdp](https://linuxunplugged.com/tags/krdp), [kwin](https://linuxunplugged.com/tags/kwin), [linux desktop](https://linuxunplugged.com/tags/linux%20desktop), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [mastadon](https://linuxunplugged.com/tags/mastadon), [nixos](https://linuxunplugged.com/tags/nixos), [no-li brewhouse](https://linuxunplugged.com/tags/no-li%20brewhouse), [nostr](https://linuxunplugged.com/tags/nostr), [not-michigan](https://linuxunplugged.com/tags/not-michigan), [openbsd](https://linuxunplugged.com/tags/openbsd), [packagekit](https://linuxunplugged.com/tags/packagekit), [plasma 6.1](https://linuxunplugged.com/tags/plasma%206.1), [plasma 6.1.1](https://linuxunplugged.com/tags/plasma%206.1.1), [rdp](https://linuxunplugged.com/tags/rdp), [shake-that-cursor](https://linuxunplugged.com/tags/shake-that-cursor), [spokane meetup](https://linuxunplugged.com/tags/spokane%20meetup), [tailscale](https://linuxunplugged.com/tags/tailscale), [tlp](https://linuxunplugged.com/tags/tlp), [triple buffering](https://linuxunplugged.com/tags/triple%20buffering), [wayland](https://linuxunplugged.com/tags/wayland), [🦒](https://linuxunplugged.com/tags/%F0%9F%A6%92)

--- a/docs/linux-unplugged/2024/episode-570.md
+++ b/docs/linux-unplugged/2024/episode-570.md
@@ -1,0 +1,49 @@
+# LUP 570: RegreSSHion Strikes
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+HnALjuia?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-07-07
+* Duration: 47 mins 6 secs
+
+## About this episode
+
+We dig into the RegreSSHion bug, debate it's real threat and explore clever tools to build a tasty fried onion around your system.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Spokane Meetup - No-Li Brewhouse · JB Events on Gathio](https://jbevents.hybridsarcasm.xyz/mqsu0M5BiBA_2J9GS5ODK "Spokane Meetup - No-Li Brewhouse · JB Events on Gathio")
+  * [Plasma/Krunner Docs](https://userbase.kde.org/Plasma/Krunner "Plasma/Krunner Docs") — Brent's tip: 'https://search.nixos.org/options?query=\\{@}' (the '\\{@}' is the magic sauce)
+  * [autossh](https://www.harding.motd.ca/autossh/ "autossh") — Automatically restart SSH sessions and tunnels
+  * [autossh on GitHub](https://github.com/Autossh/autossh "autossh on GitHub")
+  * [Spokane Meetup](https://www.meetup.com/jupiterbroadcasting/events/301471716/ "Spokane Meetup") — No-Li Brewhouse, Sat, Jul 13, 2024, 4:00 PM
+  * [RegreSSHion](https://www.phoronix.com/news/RegreSSHion-CVE-2024-6387 "RegreSSHion") — Remote Code Execution Vulnerability In OpenSSH Server
+  * [regreSSHion](https://blog.qualys.com/vulnerabilities-threat-research/2024/07/01/regresshion-remote-unauthenticated-code-execution-vulnerability-in-openssh-server "regreSSHion") — Remote Unauthenticated Code Execution Vulnerability in OpenSSH server.
+  * [NixOS Security advisory: OpenSSH CVE-2024-6387 “regreSSHion” – update your servers ASAP](https://discourse.nixos.org/t/security-advisory-openssh-cve-2024-6387-regresshion-update-your-servers-asap/48220 "NixOS Security advisory: OpenSSH CVE-2024-6387 “regreSSHion” – update your servers ASAP")
+  * [Nasty regreSSHion bug affects around 700K Linux systems](https://www.theregister.com/2024/07/01/regresshion_openssh/ "Nasty regreSSHion bug affects around 700K Linux systems")
+  * [Qualys CVE-2024-6387 Write-up](https://www.qualys.com/2024/07/01/cve-2024-6387/regresshion.txt "Qualys CVE-2024-6387 Write-up")
+  * [Letmein: Authenticating port knocker - Written in Rust](https://github.com/mbuesch/letmein "Letmein: Authenticating port knocker - Written in Rust") — Letmein is a simple port knocker with a simple and secure authentication mechanism. It can be used to harden against pre-authentication attacks on services like SSH, VPN, IMAP and many more.
+  * [fwknop: Single Packet Authorization > Port Knocking](https://www.cipherdyne.org/fwknop/ "fwknop: Single Packet Authorization > Port Knocking") — fwknop stands for the "FireWall KNock OPerator", and implements an authorization scheme called Single Packet Authorization (SPA). This method of authorization is based around a default-drop packet filter
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [Jeff links: How to run non-nix executables?](https://nix.dev/guides/faq#how-to-run-non-nix-executables "Jeff links: How to run non-nix executables?")
+  * [pick: stu](https://github.com/lusingander/stu "pick: stu") — TUI (Terminal/Text UI) application for AWS S3
+
+
+
+## Tags
+
+[32-bit](https://linuxunplugged.com/tags/32-bit), [ars](https://linuxunplugged.com/tags/ars), [atomic clock](https://linuxunplugged.com/tags/atomic%20clock), [autossh](https://linuxunplugged.com/tags/autossh), [cve](https://linuxunplugged.com/tags/cve), [dan goodin](https://linuxunplugged.com/tags/dan%20goodin), [denial-of-service](https://linuxunplugged.com/tags/denial-of-service), [exploit](https://linuxunplugged.com/tags/exploit), [fail2ban](https://linuxunplugged.com/tags/fail2ban), [firewall](https://linuxunplugged.com/tags/firewall), [firewall knock operator](https://linuxunplugged.com/tags/firewall%20knock%20operator), [fried onion](https://linuxunplugged.com/tags/fried%20onion), [fwknop](https://linuxunplugged.com/tags/fwknop), [jb time](https://linuxunplugged.com/tags/jb%20time), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kaspersky](https://linuxunplugged.com/tags/kaspersky), [kdeconnect](https://linuxunplugged.com/tags/kdeconnect), [krunner](https://linuxunplugged.com/tags/krunner), [letmein](https://linuxunplugged.com/tags/letmein), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [malicious payloads](https://linuxunplugged.com/tags/malicious%20payloads), [nixos](https://linuxunplugged.com/tags/nixos), [openssh](https://linuxunplugged.com/tags/openssh), [port knocking](https://linuxunplugged.com/tags/port%20knocking), [qualys](https://linuxunplugged.com/tags/qualys), [rce](https://linuxunplugged.com/tags/rce), [regresshion](https://linuxunplugged.com/tags/regresshion), [regression](https://linuxunplugged.com/tags/regression), [security advisory](https://linuxunplugged.com/tags/security%20advisory), [server hardening](https://linuxunplugged.com/tags/server%20hardening), [spa](https://linuxunplugged.com/tags/spa), [spokane meetup](https://linuxunplugged.com/tags/spokane%20meetup), [stan kaminsky](https://linuxunplugged.com/tags/stan%20kaminsky), [stu](https://linuxunplugged.com/tags/stu), [tailscale](https://linuxunplugged.com/tags/tailscale), [tui](https://linuxunplugged.com/tags/tui), [vulnerability](https://linuxunplugged.com/tags/vulnerability)

--- a/docs/linux-unplugged/2024/episode-571.md
+++ b/docs/linux-unplugged/2024/episode-571.md
@@ -1,0 +1,52 @@
+# LUP 571: Multi-Machine Lifestyle
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+JL_rtRrx?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-07-14
+* Duration: 79 mins 15 secs
+
+## About this episode
+
+Wes reports from the Skunkworks lab, and Brent tells us about his new computing lifestyle.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Nix Nerds Matrix Room](https://matrix.to/#/#nixnerds:jupiterbroadcasting.com "Nix Nerds Matrix Room")
+  * [Beelink SER5 Mini PC](https://www.bee-link.com/products/beelink-ser5-max-5800h "Beelink SER5 Mini PC")
+  * [Minisforum UM690 Pro](https://store.minisforum.com/products/minisforum-um690-pro "Minisforum UM690 Pro")
+  * [pyenv-flake: experimental nix flake that can build pyenv pythons](https://github.com/noblepayne/pyenv-flake "pyenv-flake: experimental nix flake that can build pyenv pythons")
+  * [dotenvx-flake: A nix flake for dotenvx](https://github.com/noblepayne/dotenvx-flake/tree/main "dotenvx-flake: A nix flake for dotenvx")
+  * [auto-patchelf.sh - NixOS/nixpkgs](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/setup-hooks/auto-patchelf.sh "auto-patchelf.sh - NixOS/nixpkgs")
+  * [Packaging/Binaries - NixOS Wiki](https://wiki.nixos.org/wiki/Packaging/Binaries "Packaging/Binaries - NixOS Wiki")
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [Try the JB Test Gathio Instance hosted by HybridSarcasm](https://jbevents.hybridsarcasm.xyz "Try the JB Test Gathio Instance hosted by HybridSarcasm")
+  * [Berlin with Brent: September Meetup at Nextcloud Conference · JB Events](https://jbevents.hybridsarcasm.xyz/cCmAVin8WjSzJoFofLdFT?e=7vai4besd97wy6g8lvd8g6ehi4shfjow "Berlin with Brent: September Meetup at Nextcloud Conference · JB Events")
+  * [Fix Kate sudo saves - use Plasma 6 version of Kate by MarkSort · Pull Request #3 · ChrisLAS/nix](https://github.com/ChrisLAS/nix/pull/3 "Fix Kate sudo saves - use Plasma 6 version of Kate by MarkSort · Pull Request #3 · ChrisLAS/nix")
+  * [Running OpenBSD 7.5 on your laptop is really hard (not)](https://www.k58.uk/openbsd.html "Running OpenBSD 7.5 on your laptop is really hard \(not\)") — I couldn't use OpenBSD exclusively; there's software that I need/want which isn't available. But I do appreciate certain of OpenBSD's qualities: it's a simple, ultra-lightweight, traditional UNIX. I have an ancient ThinkPad running OpenBSD configured as a minimalist desktop: it's nice for focused work. Sure, it can't run Steam or play Netflix, but sometimes that's a plus...
+  * [@fabean's NixOS configs](https://gitlab.com/fabean/fabeanos "@fabean's NixOS configs")
+  * [IBM Classroom LAN Administration System V 1.30 User Guide](https://archive.org/details/ibm-classroom-lan-administration-system-v-1.30-user-guide "IBM Classroom LAN Administration System V 1.30 User Guide")
+  * [0xchat: Secure chat built on Nostr](https://0xchat.com/#/ "0xchat: Secure chat built on Nostr")
+  * [Get NIP-05 verified](https://nostr.how/en/guides/get-verified "Get NIP-05 verified")
+  * [Pick: termscp](https://github.com/veeso/termscp "Pick: termscp") — 🖥 A feature rich terminal UI file transfer and explorer with support for SCP/SFTP/FTP/S3/SMB
+  * [Learn Nix The Fun Way](https://fzakaria.com/2024/07/05/learn-nix-the-fun-way.html "Learn Nix The Fun Way") — Sure, it’s sort of portable, if you tell the person running it to have curl and jq. What if you relied on a specific version of either though? Nix guarantees portability.
+
+
+
+## Tags
+
+[0xchat](https://linuxunplugged.com/tags/0xchat), [1.21 gigawatts!](https://linuxunplugged.com/tags/1.21%20gigawatts!), [autopatchelf](https://linuxunplugged.com/tags/autopatchelf), [beelink ser5](https://linuxunplugged.com/tags/beelink%20ser5), [circle of trust](https://linuxunplugged.com/tags/circle%20of%20trust), [decentralized identity](https://linuxunplugged.com/tags/decentralized%20identity), [dotenvx](https://linuxunplugged.com/tags/dotenvx), [fear of updates](https://linuxunplugged.com/tags/fear%20of%20updates), [freeoffice](https://linuxunplugged.com/tags/freeoffice), [gathio](https://linuxunplugged.com/tags/gathio), [great scott!](https://linuxunplugged.com/tags/great%20scott!), [headscale](https://linuxunplugged.com/tags/headscale), [jack](https://linuxunplugged.com/tags/jack), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kate](https://linuxunplugged.com/tags/kate), [kate sudo saves](https://linuxunplugged.com/tags/kate%20sudo%20saves), [learn nix the fun way](https://linuxunplugged.com/tags/learn%20nix%20the%20fun%20way), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [lup 100](https://linuxunplugged.com/tags/lup%20100), [minisforum um690 pro](https://linuxunplugged.com/tags/minisforum%20um690%20pro), [minisforum um790 pro](https://linuxunplugged.com/tags/minisforum%20um790%20pro), [nip-05 verified](https://linuxunplugged.com/tags/nip-05%20verified), [nix](https://linuxunplugged.com/tags/nix), [nix shell](https://linuxunplugged.com/tags/nix%20shell), [nixos](https://linuxunplugged.com/tags/nixos), [nostr](https://linuxunplugged.com/tags/nostr), [openbsd desktop challenge](https://linuxunplugged.com/tags/openbsd%20desktop%20challenge), [opensuse](https://linuxunplugged.com/tags/opensuse), [oxchat](https://linuxunplugged.com/tags/oxchat), [patchelf](https://linuxunplugged.com/tags/patchelf), [pipewire](https://linuxunplugged.com/tags/pipewire), [plasma 6](https://linuxunplugged.com/tags/plasma%206), [postgres](https://linuxunplugged.com/tags/postgres), [psycopg2](https://linuxunplugged.com/tags/psycopg2), [pw-jack](https://linuxunplugged.com/tags/pw-jack), [pyenv](https://linuxunplugged.com/tags/pyenv), [python](https://linuxunplugged.com/tags/python), [rcs](https://linuxunplugged.com/tags/rcs), [reaper](https://linuxunplugged.com/tags/reaper), [rolling distro](https://linuxunplugged.com/tags/rolling%20distro), [skunkworks](https://linuxunplugged.com/tags/skunkworks), [termscp](https://linuxunplugged.com/tags/termscp), [tumbleweed](https://linuxunplugged.com/tags/tumbleweed), [vercel](https://linuxunplugged.com/tags/vercel), [wps office](https://linuxunplugged.com/tags/wps%20office)

--- a/docs/linux-unplugged/2024/episode-572.md
+++ b/docs/linux-unplugged/2024/episode-572.md
@@ -1,0 +1,70 @@
+# LUP 572: Data Security Only a Maniac Could Love
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+9chLAchm?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-07-21
+* Duration: 91 mins 29 secs
+
+## About this episode
+
+Wes' self-decrypting bcachefs disk and a GrapheneOS twist that'll make you ditch your iPhone.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+* [Tomasz Frątczak](https://linuxunplugged.com/guests/tomasz)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [clevis](https://github.com/latchset/clevis "clevis") — Clevis is a pluggable framework for automated decryption. It can be used to provide automated decryption of data or even automated unlocking of LUKS volumes.
+  * [bcachefs Encryption](https://bcachefs.org/Encryption/ "bcachefs Encryption")
+  * [What measured boot and trusted boot means for Linux](https://opensource.com/article/20/10/measured-trusted-boot "What measured boot and trusted boot means for Linux")
+  * [Automatically decrypt your disk using TPM2](https://fedoramagazine.org/automatically-decrypt-your-disk-using-tpm2/ "Automatically decrypt your disk using TPM2") — Entering the passphrase to decrypt the disk at boot can become quite tedious. On modern systems a secure hardware chip called “TPM” (Trusted Platform Module) can store a secret and automatically decrypt your disk. This is an alternative factor, not a second factor. Keep that in mind.
+  * [Use systemd-cryptenroll with FIDO U2F or TPM2 to decrypt your disk](https://fedoramagazine.org/use-systemd-cryptenroll-with-fido-u2f-or-tpm2-to-decrypt-your-disk/ "Use systemd-cryptenroll with FIDO U2F or TPM2 to decrypt your disk")
+  * [Automatic LUKS 2 disk decryption with TPM 2 on Fedora](https://kowalski7cc.xyz/blog/luks2-tpm2-clevis-fedora31/ "Automatic LUKS 2 disk decryption with TPM 2 on Fedora")
+  * [Safe automatic decryption of LUKS partition using TPM2 | 221b](https://221b.uk/safe-automatic-decryption-luks-partition-tpm2 "Safe automatic decryption of LUKS partition using TPM2 | 221b")
+  * [FOSDEM 2024: Clevis/Tang - unattended boot of an encrypted NixOS system](https://fosdem.org/2024/schedule/event/fosdem-2024-3044-clevis-tang-unattended-boot-of-an-encrypted-nixos-system/ "FOSDEM 2024: Clevis/Tang - unattended boot of an encrypted NixOS system")
+  * [Clevis & Tang on NixOS Slides](https://camillemondon.com/talks/fosdem24-clevis/#/title-slide "Clevis & Tang on NixOS Slides")
+  * [Decrypt LUKS volumes with a TPM on Fedora Linux](https://gist.github.com/jdoss/777e8b52c8d88eb87467935769c98a95 "Decrypt LUKS volumes with a TPM on Fedora Linux")
+  * [Self-Hosted 127: Can't Fix What You Don't Track](https://selfhosted.show/127 "Self-Hosted 127: Can't Fix What You Don't Track")
+  * [Garmin Forerunner 265](https://www.amazon.com/dp/B0BS1T9J4Y "Garmin Forerunner 265") — Forerunner 265 is a running smartwatch with a touchscreen AMOLED display, training metrics, phone-free music, & up to 13 days of battery life in smartwatch
+  * [HRV Status](https://www.garmin.com/en-US/garmin-technology/health-science/hrv-status/ "HRV Status")
+  * [Garmin Sleep Tracking](https://www.garmin.com/en-US/garmin-technology/health-science/sleep-tracking/ "Garmin Sleep Tracking")
+  * [Nap Detection](https://www.garmin.com/en-US/garmin-technology/health-science/nap-detection/ "Nap Detection")
+  * [Garmin Pay](https://www.garmin.com/en-US/garmin-pay/ "Garmin Pay")
+  * [Tribit Stormbox Micro 2 Wireless Portable Speaker: 10W](https://www.amazon.com/dp/B09Q59321N "Tribit Stormbox Micro 2 Wireless Portable Speaker: 10W")
+  * [USB-C Charging Converter for Garmin Watch Without Charger Cable](https://www.amazon.com/dp/B0BK4QD665 "USB-C Charging Converter for Garmin Watch Without Charger Cable")
+  * [Obtainium](https://github.com/ImranR98/Obtainium "Obtainium") — Obtainium allows you to install and update apps directly from their releases pages, and receive notifications when new releases are made available.
+  * [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens "Managing your personal access tokens")
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [Iotas](https://flathub.org/apps/org.gnome.World.Iotas "Iotas") — Iotas aims to provide distraction-free note taking with optional speedy sync with Nextcloud Notes.
+  * [LINUX Unplugged 567: So Long sudo](https://linuxunplugged.com/567 "LINUX Unplugged 567: So Long sudo")
+  * [Celeste](https://github.com/hwittenborn/celeste "Celeste") — GUI file synchronization client that can sync with any cloud provider
+  * [vt52's Blog: Migrating from NixOS channels to Flakes](https://tty.is/blog/migrating-to-flakes.html "vt52's Blog: Migrating from NixOS channels to Flakes")
+  * [FUTO Keyboard](https://keyboard.futo.org/ "FUTO Keyboard")
+  * [autossh](https://www.harding.motd.ca/autossh/ "autossh")
+  * [LINUX Unplugged 570: RegreSSHion Strikes](https://linuxunplugged.com/570 "LINUX Unplugged 570: RegreSSHion Strikes")
+  * [Aeon](https://aeondesktop.github.io/ "Aeon") — The Linux Desktop for people who want to "get stuff done"
+  * [Aeon: openSUSE for lazy developers](https://lwn.net/Articles/977987/ "Aeon: openSUSE for lazy developers")
+  * [Grayjay](https://grayjay.app/ "Grayjay") — Follow Creators Not Platforms
+  * [Grayjay on GitLab](https://gitlab.futo.org/videostreaming/grayjay "Grayjay on GitLab")
+  * [CrowdSec](https://www.crowdsec.net/ "CrowdSec")
+  * [Bustle](https://flathub.org/apps/org.freedesktop.Bustle "Bustle") — Bustle draws sequence diagrams of D-Bus activity. It shows signal emissions, method calls and their corresponding returns, with time stamps for each individual event and the duration of each method call. This can help you check for unwanted D-Bus traffic, and pinpoint why your D-Bus-based application is not performing as well as you like. It also provides statistics like signal frequencies and average method call times.
+  * [open-and-shut](https://github.com/veggiedefender/open-and-shut "open-and-shut") — Type in Morse code by repeatedly slamming your laptop shut
+
+
+
+## Tags
+
+[apple watch killer](https://linuxunplugged.com/tags/apple%20watch%20killer), [automated decryption](https://linuxunplugged.com/tags/automated%20decryption), [autossh](https://linuxunplugged.com/tags/autossh), [barix](https://linuxunplugged.com/tags/barix), [bazzite](https://linuxunplugged.com/tags/bazzite), [bcachefs](https://linuxunplugged.com/tags/bcachefs), [bcachefs encryption](https://linuxunplugged.com/tags/bcachefs%20encryption), [bcachefs on rootfs](https://linuxunplugged.com/tags/bcachefs%20on%20rootfs), [blue bubbles](https://linuxunplugged.com/tags/blue%20bubbles), [bluefin](https://linuxunplugged.com/tags/bluefin), [boot chain](https://linuxunplugged.com/tags/boot%20chain), [bustle](https://linuxunplugged.com/tags/bustle), [celeste](https://linuxunplugged.com/tags/celeste), [clevis](https://linuxunplugged.com/tags/clevis), [coinbase](https://linuxunplugged.com/tags/coinbase), [contactless payment](https://linuxunplugged.com/tags/contactless%20payment), [crowdsec](https://linuxunplugged.com/tags/crowdsec), [disk encryption](https://linuxunplugged.com/tags/disk%20encryption), [encryption](https://linuxunplugged.com/tags/encryption), [fedora](https://linuxunplugged.com/tags/fedora), [flakes tutorial](https://linuxunplugged.com/tags/flakes%20tutorial), [fosdem](https://linuxunplugged.com/tags/fosdem), [framework 13](https://linuxunplugged.com/tags/framework%2013), [futo](https://linuxunplugged.com/tags/futo), [futo keyboard](https://linuxunplugged.com/tags/futo%20keyboard), [garmin](https://linuxunplugged.com/tags/garmin), [gentoo challenge](https://linuxunplugged.com/tags/gentoo%20challenge), [gigawatt boost](https://linuxunplugged.com/tags/gigawatt%20boost), [github rate limiting](https://linuxunplugged.com/tags/github%20rate%20limiting), [grapheneos](https://linuxunplugged.com/tags/grapheneos), [grayjay](https://linuxunplugged.com/tags/grayjay), [guix](https://linuxunplugged.com/tags/guix), [iotas](https://linuxunplugged.com/tags/iotas), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [libreoffice](https://linuxunplugged.com/tags/libreoffice), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [luks](https://linuxunplugged.com/tags/luks), [measured boot](https://linuxunplugged.com/tags/measured%20boot), [morse code](https://linuxunplugged.com/tags/morse%20code), [nextcloud](https://linuxunplugged.com/tags/nextcloud), [nixos](https://linuxunplugged.com/tags/nixos), [obtainium](https://linuxunplugged.com/tags/obtainium), [open-and-shut](https://linuxunplugged.com/tags/open-and-shut), [opensuse aeon](https://linuxunplugged.com/tags/opensuse%20aeon), [pcr](https://linuxunplugged.com/tags/pcr), [pcr 7](https://linuxunplugged.com/tags/pcr%207), [rclone](https://linuxunplugged.com/tags/rclone), [rolling release](https://linuxunplugged.com/tags/rolling%20release), [rust](https://linuxunplugged.com/tags/rust), [slam your laptop lid](https://linuxunplugged.com/tags/slam%20your%20laptop%20lid), [sleephq](https://linuxunplugged.com/tags/sleephq), [smartwatch](https://linuxunplugged.com/tags/smartwatch), [systemd-cryptenroll](https://linuxunplugged.com/tags/systemd-cryptenroll), [tang](https://linuxunplugged.com/tags/tang), [that hash lifestyle](https://linuxunplugged.com/tags/that%20hash%20lifestyle), [tpm](https://linuxunplugged.com/tags/tpm), [windows outage](https://linuxunplugged.com/tags/windows%20outage), [🦒](https://linuxunplugged.com/tags/%F0%9F%A6%92)

--- a/docs/linux-unplugged/2024/episode-573.md
+++ b/docs/linux-unplugged/2024/episode-573.md
@@ -1,0 +1,52 @@
+# LUP 573: Universal Blue Man Group
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+SbTbf_2x?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-07-28
+* Duration: 79 mins 6 secs
+
+## About this episode
+
+Think Silverblue, but with cloud-native tooling used to build it. From Aurora to Bazzite, our impressions of the ambitious Universal Blue project.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Universal Blue](https://universal-blue.org/ "Universal Blue") — The Universal Blue project builds a diverse set of continuously delivered operating system images using Fedora Atomic Desktop's support for OCI/Docker containers.
+  * [Universal Blue Architecture Diagram](https://universal-blue.discourse.group/t/architecture-diagram/1523 "Universal Blue Architecture Diagram")
+  * [Aurora](https://getaurora.dev/ "Aurora") — Aurora is a clean and reliable desktop operating system for every type of user. Many batteries included.
+  * [Bluefin](https://projectbluefin.io/ "Bluefin") — Bluefin is a custom image of Fedora Silverblue offering the best of both worlds: The reliability and ease of use of a Chromebook and the power of a GNOME desktop.
+  * [Bazzite](https://bazzite.gg/ "Bazzite") — The next generation of Linux Gaming for all of your devices - including your favorite handheld.
+  * [uCore](https://github.com/ublue-os/ucore "uCore") — An OCI base image of Fedora CoreOS with batteries included; a lightweight server image including most used services or the building blocks to host them.
+  * [Bazzite Desktop Environment Tweaks - Bazzite - Docs - Universal Blue](https://universal-blue.discourse.group/docs?topic=574 "Bazzite Desktop Environment Tweaks - Bazzite - Docs - Universal Blue")
+  * [Installing and Managing AppImages on Bazzite - Bazzite - Docs - Universal Blue](https://universal-blue.discourse.group/docs?topic=2641 "Installing and Managing AppImages on Bazzite - Bazzite - Docs - Universal Blue")
+  * [Universal Blue Contributing Guide](https://universal-blue.discourse.group/docs?topic=81 "Universal Blue Contributing Guide")
+  * [Jazz up your Bluefin command line with some bling! [YouTube]](https://www.youtube.com/watch?v=H8-rLe6fXYw "Jazz up your Bluefin command line with some bling! \[YouTube\]")
+  * [Jorge Castro on YouTube](https://www.youtube.com/@JorgeCastro "Jorge Castro on YouTube")
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [zap.store](https://zap.store/download/ "zap.store") — a permissionless app store.
+  * [Asking AI To Make A Caveman Rock Song - Me Like Rock](https://www.youtube.com/watch?v=rvCHh-mckmw&pp=ygUUc2V0aCBkcnVtcyByb2NrIHJvbGw%3D "Asking AI To Make A Caveman Rock Song - Me Like Rock")
+  * [winapps](https://github.com/winapps-org/winapps "winapps") — Run Windows applications (including Microsoft 365 and Adobe Creative Cloud) on GNU/Linux with KDE, GNOME or XFCE, integrated seamlessly as if they were native to the OS.
+  * [The Mooltipass Hardware Authenticator](https://www.themooltipass.com/ "The Mooltipass Hardware Authenticator") — A Simple Hardware Authenticator
+  * [ptyxis](https://gitlab.gnome.org/chergert/ptyxis "ptyxis") — Ptyxis is a terminal for GNOME with first-class support for containers.
+  * [Gearlever](https://github.com/mijorus/gearlever "Gearlever") — Manage AppImages with ease 📦
+
+
+
+## Tags
+
+[anacaonda](https://linuxunplugged.com/tags/anacaonda), [aurora](https://linuxunplugged.com/tags/aurora), [bazzite](https://linuxunplugged.com/tags/bazzite), [bcachefs](https://linuxunplugged.com/tags/bcachefs), [bitlocker](https://linuxunplugged.com/tags/bitlocker), [bluebuild](https://linuxunplugged.com/tags/bluebuild), [bluefin](https://linuxunplugged.com/tags/bluefin), [bootc](https://linuxunplugged.com/tags/bootc), [brentley's gentoo fund](https://linuxunplugged.com/tags/brentley's%20gentoo%20fund), [brew](https://linuxunplugged.com/tags/brew), [clevis](https://linuxunplugged.com/tags/clevis), [cloud-native](https://linuxunplugged.com/tags/cloud-native), [container fatigue](https://linuxunplugged.com/tags/container%20fatigue), [containerfile](https://linuxunplugged.com/tags/containerfile), [disk encryption](https://linuxunplugged.com/tags/disk%20encryption), [fedora atomic desktop](https://linuxunplugged.com/tags/fedora%20atomic%20desktop), [fedora coreos](https://linuxunplugged.com/tags/fedora%20coreos), [flatpak](https://linuxunplugged.com/tags/flatpak), [floppy disk](https://linuxunplugged.com/tags/floppy%20disk), [garmin](https://linuxunplugged.com/tags/garmin), [gearlever](https://linuxunplugged.com/tags/gearlever), [gentoo](https://linuxunplugged.com/tags/gentoo), [glue balloons](https://linuxunplugged.com/tags/glue%20balloons), [gnome](https://linuxunplugged.com/tags/gnome), [immutable linux](https://linuxunplugged.com/tags/immutable%20linux), [jorge castro](https://linuxunplugged.com/tags/jorge%20castro), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kde](https://linuxunplugged.com/tags/kde), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [luks](https://linuxunplugged.com/tags/luks), [mooltipass](https://linuxunplugged.com/tags/mooltipass), [nixos](https://linuxunplugged.com/tags/nixos), [omakub](https://linuxunplugged.com/tags/omakub), [opensuse tumbleweed](https://linuxunplugged.com/tags/opensuse%20tumbleweed), [ostree. fedora](https://linuxunplugged.com/tags/ostree.%20fedora), [plasma 6](https://linuxunplugged.com/tags/plasma%206), [ptyxis](https://linuxunplugged.com/tags/ptyxis), [rpm-ostree](https://linuxunplugged.com/tags/rpm-ostree), [silverblue](https://linuxunplugged.com/tags/silverblue), [steam](https://linuxunplugged.com/tags/steam), [ucore](https://linuxunplugged.com/tags/ucore), [universal blue](https://linuxunplugged.com/tags/universal%20blue), [yast](https://linuxunplugged.com/tags/yast)

--- a/docs/linux-unplugged/2024/episode-574.md
+++ b/docs/linux-unplugged/2024/episode-574.md
@@ -1,0 +1,43 @@
+# LUP 574: COSMIC Encounter
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+Fk6cpHeL?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-08-04
+* Duration: 65 mins 26 secs
+
+## About this episode
+
+The COSMIC desktop is just around the corner. We get the inside scoop from System76 and go hands-on with an early press build.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [System76 tips Fedora Cosmic spin for 2025 release with Fedora 42](https://www.notebookcheck.net/System76-tips-Fedora-Cosmic-spin-for-2025-release-with-Fedora-42.867943.0.html "System76 tips Fedora Cosmic spin for 2025 release with Fedora 42") — It looks like System76's exciting new Rust-based Cosmic DE will get an official Fedora spin in the upcoming Fedora 42, potentially giving Linux users with bleeding-edge hardware an official way to try Cosmic.
+  * [Pop!_OS Mattermost](https://chat.pop-os.org/ "Pop!_OS Mattermost") — An excellent place to engage if you want to bring COSMIC to a distro near you.
+  * [iced](https://iced.rs/ "iced") — A cross-platform GUI library for Rust
+  * [Smithay](https://github.com/Smithay/smithay "Smithay") — A smithy for rusty wayland compositor
+  * [Testing COSMIC](https://github.com/pop-os/cosmic-epoch?tab=readme-ov-file#testing "Testing COSMIC") — The easiest way to test COSMIC DE currently is by building a systemd system extension.
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [Portal:Kalpa - openSUSE Wiki](https://en.opensuse.org/Portal:Kalpa "Portal:Kalpa - openSUSE Wiki") — openSUSE MicroOS Desktop Gnome was renamed to openSUSE Aeon, and the Plasma Desktop version is being renamed to openSUSE Kalpa.
+  * [pop-os/kernelstub: A simple EFI boot manager manager for Linux](https://github.com/pop-os/kernelstub "pop-os/kernelstub: A simple EFI boot manager manager for Linux")
+  * [Alpaca](https://jeffser.com/alpaca/ "Alpaca") — GTK App to Chat with local AI models
+  * [Alpaca on FlatHub](https://flathub.org/apps/com.jeffser.Alpaca "Alpaca on FlatHub")
+
+
+
+## Tags
+
+[aeon](https://linuxunplugged.com/tags/aeon), [alpha release](https://linuxunplugged.com/tags/alpha%20release), [app store](https://linuxunplugged.com/tags/app%20store), [appimage](https://linuxunplugged.com/tags/appimage), [bazzite](https://linuxunplugged.com/tags/bazzite), [bootc](https://linuxunplugged.com/tags/bootc), [cinnamon](https://linuxunplugged.com/tags/cinnamon), [compositor](https://linuxunplugged.com/tags/compositor), [configuration](https://linuxunplugged.com/tags/configuration), [cosmic](https://linuxunplugged.com/tags/cosmic), [cpap](https://linuxunplugged.com/tags/cpap), [desktop environment](https://linuxunplugged.com/tags/desktop%20environment), [fedora](https://linuxunplugged.com/tags/fedora), [file manager](https://linuxunplugged.com/tags/file%20manager), [full disk encryption](https://linuxunplugged.com/tags/full%20disk%20encryption), [garmin](https://linuxunplugged.com/tags/garmin), [gear lever](https://linuxunplugged.com/tags/gear%20lever), [gentoo challenge](https://linuxunplugged.com/tags/gentoo%20challenge), [github actions](https://linuxunplugged.com/tags/github%20actions), [gui](https://linuxunplugged.com/tags/gui), [iced](https://linuxunplugged.com/tags/iced), [immutable operating systems](https://linuxunplugged.com/tags/immutable%20operating%20systems), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kalpa](https://linuxunplugged.com/tags/kalpa), [keyboard shortcuts](https://linuxunplugged.com/tags/keyboard%20shortcuts), [kitterman creative](https://linuxunplugged.com/tags/kitterman%20creative), [linux](https://linuxunplugged.com/tags/linux), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [manjaro](https://linuxunplugged.com/tags/manjaro), [nixos](https://linuxunplugged.com/tags/nixos), [oscar](https://linuxunplugged.com/tags/oscar), [performance](https://linuxunplugged.com/tags/performance), [pop!_os](https://linuxunplugged.com/tags/pop!_os), [portability](https://linuxunplugged.com/tags/portability), [rust](https://linuxunplugged.com/tags/rust), [screenshot tool](https://linuxunplugged.com/tags/screenshot%20tool), [secure boot](https://linuxunplugged.com/tags/secure%20boot), [smb shares](https://linuxunplugged.com/tags/smb%20shares), [smithay](https://linuxunplugged.com/tags/smithay), [steam deck](https://linuxunplugged.com/tags/steam%20deck), [system76](https://linuxunplugged.com/tags/system76), [themes](https://linuxunplugged.com/tags/themes), [tpm](https://linuxunplugged.com/tags/tpm), [tumbleweed](https://linuxunplugged.com/tags/tumbleweed), [universal blue](https://linuxunplugged.com/tags/universal%20blue), [wayland](https://linuxunplugged.com/tags/wayland)

--- a/docs/linux-unplugged/2024/episode-575.md
+++ b/docs/linux-unplugged/2024/episode-575.md
@@ -1,0 +1,55 @@
+# LUP 575: Brent's Busted Builds
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+wORg0sdX?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-08-11
+* Duration: 86 mins 18 secs
+
+## About this episode
+
+Brent's computer pulls an all-nighter at the worst possible moment, and the hits keep coming for open-source Android distributions and our new 2FA tool.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Toronto Meetup](https://www.meetup.com/jupiterbroadcasting/events/302700160/?slug=jupiterbroadcasting&eventId=302700160 "Toronto Meetup") — Thursday, August 29, 2024 from 6:00 PM to 8:00 PM EDT
+  * [Sacramento LUG Meetup](https://jbevents.hybridsarcasm.xyz/Clz1m1xiBAit6AzC6joWw "Sacramento LUG Meetup") — Saturday September 7th, 2024 from 10:00 AM to 2:00 PM PDT
+  * [Anker PowerConf S330 USB Speakerphone](https://www.amazon.com/Anker-Speakerphone-Conference-Enhancement-Microphones/dp/B09FJ7LWX4 "Anker PowerConf S330 USB Speakerphone")
+  * [Corsair Void RGB Elite Wireless Premium Gaming Headset](https://www.amazon.com/gp/product/B07X8SJ8HM/ "Corsair Void RGB Elite Wireless Premium Gaming Headset")
+  * [Loss of popular 2FA tool puts security-minded GrapheneOS in a paradox](https://arstechnica.com/gadgets/2024/07/loss-of-popular-2fa-tool-puts-security-minded-grapheneos-in-a-paradox/ "Loss of popular 2FA tool puts security-minded GrapheneOS in a paradox")
+  * [GrapheneOS on X](https://x.com/GrapheneOS/status/1818415391791570995 "GrapheneOS on X") — Google can either permit GrapheneOS in the Play Integrity API in the near future 
+  * [GrapheneOS on X](https://x.com/GrapheneOS/status/1818430429264838886 "GrapheneOS on X") — If Authy insists on using it, they should use the standard Android hardware attestation API to permit using GrapheneOS too. Banning 250k+ people with the most secure smartphones from using your app is anti-security, not pro-security.
+  * [GrapheneOS on X](https://x.com/GrapheneOS/status/1818904140723961942 "GrapheneOS on X") — Authy simply delegated checking device integrity to Google. It's Google choosing to block GrapheneOS users from using Authy. Google chooses to allow using a device with no security patches for the past 8 years but bans using an OS much more secure than the stock Pixel OS.
+  * [Twilio kills off Authy for desktop, forcibly logs out all users](https://www.bleepingcomputer.com/news/security/twilio-kills-off-authy-for-desktop-forcibly-logs-out-all-users/ "Twilio kills off Authy for desktop, forcibly logs out all users")
+  * [GrapheneOS on X](https://x.com/GrapheneOS/status/1819831882839949375 "GrapheneOS on X") — Our latest release with prevention for most VPN app DNS leaks is currently available in our Alpha and Beta channels. We need more feedback from testing VPN apps and services with leak blocking toggled on, which GrapheneOS already enables by default.
+  * [GrapheneOS on X](https://x.com/GrapheneOS/status/1819891869620240616 "GrapheneOS on X") — Our current approach to DNS leak blocking appears to work well without breaking compatibility. We've made progress towards fixing a related issue for some VPN apps where rare connections are made to VPN DNS outside of the tunnel. We can hopefully ship stricter enforcement soon.
+  * [GrapheneOS on X](https://x.com/GrapheneOS/status/1819083612949717119 "GrapheneOS on X") — We've become aware of another company selling devices with GrapheneOS while spreading harmful misinformation about it to promote insecure products. We're making our usual attempt at resolving things privately. However, we need to quickly address what has been claimed regardless.
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [How You Guys Expect to Beat Me?](https://youtu.be/g9MqOgYJt-8 "How You Guys Expect to Beat Me?")
+  * [Blue Iris Container](https://hub.docker.com/r/jshridha/blueiris/ "Blue Iris Container")
+  * [netbird](https://github.com/netbirdio/netbird "netbird") — Connect your devices into a secure WireGuard®-based overlay network with SSO, MFA and granular access controls.
+  * [netbird on GitHub](https://github.com/netbirdio/netbird "netbird on GitHub")
+  * [OpenZiti](https://openziti.io/ "OpenZiti") — Open Source Zero Trust Networking
+  * [OpenZiti on GitHub](https://github.com/openziti/ziti "OpenZiti on GitHub")
+  * [Collapse OS](http://collapseos.org/ "Collapse OS") — Bootstrap post-collapse technology
+  * [Docker-OSX](https://github.com/sickcodes/Docker-OSX?tab=readme-ov-file#generating-serial-numbers "Docker-OSX") — Run macOS VM in a Docker! Run near native OSX-KVM in Docker! X11 Forwarding! CI/CD for OS X Security Research! Docker mac Containers.
+
+
+
+## Tags
+
+[2fa](https://linuxunplugged.com/tags/2fa), [android](https://linuxunplugged.com/tags/android), [anker powerconf s330](https://linuxunplugged.com/tags/anker%20powerconf%20s330), [authy](https://linuxunplugged.com/tags/authy), [beelink](https://linuxunplugged.com/tags/beelink), [beelink ser5](https://linuxunplugged.com/tags/beelink%20ser5), [collapse os](https://linuxunplugged.com/tags/collapse%20os), [cosmic](https://linuxunplugged.com/tags/cosmic), [docker-osx](https://linuxunplugged.com/tags/docker-osx), [framework](https://linuxunplugged.com/tags/framework), [gentoo challenge](https://linuxunplugged.com/tags/gentoo%20challenge), [grapheneos](https://linuxunplugged.com/tags/grapheneos), [hyprland](https://linuxunplugged.com/tags/hyprland), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [openziti](https://linuxunplugged.com/tags/openziti), [sacramento meetup](https://linuxunplugged.com/tags/sacramento%20meetup), [services.jb.summerbreak](https://linuxunplugged.com/tags/services.jb.summerbreak), [toronto meetup](https://linuxunplugged.com/tags/toronto%20meetup), [universal blue](https://linuxunplugged.com/tags/universal%20blue), [🦒](https://linuxunplugged.com/tags/%F0%9F%A6%92)

--- a/docs/linux-unplugged/2024/episode-576.md
+++ b/docs/linux-unplugged/2024/episode-576.md
@@ -1,0 +1,53 @@
+# LUP 576: The Secret Server
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+vCu8Mx5p?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-08-18
+* Duration: 80 mins 28 secs
+
+## About this episode
+
+We reveal how we turned our humble LAN into a public server farm, all while keeping our IP address under wraps and our ISP blissfully unaware.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Toronto Meetup](https://www.meetup.com/jupiterbroadcasting/events/302700160/?eventOrigin=group_upcoming_events "Toronto Meetup") — Thursday, Aug 29, 2024
+  * [Berlin with Brent](https://www.meetup.com/jupiterbroadcasting/events/300421391/?eventOrigin=group_upcoming_events "Berlin with Brent") — September Meetup @ Nextcloud Conference, Saturday, Sep 14, 2024
+  * [Check out Alex's "Building a Colo Server" video](https://youtu.be/zC_uKX2JSfc "Check out Alex's "Building a Colo Server" video") — Building a colo server for Jupiter Broadcasting using the 45Homelab HL15 server.
+  * [Firewall - NixOS Wiki](https://wiki.nixos.org/wiki/Firewall "Firewall - NixOS Wiki")
+  * [nftables wiki](https://wiki.nftables.org/wiki-nftables/index.php/Main_Page "nftables wiki")
+  * [The netfilter.org "nftables" project](https://netfilter.org/projects/nftables/ "The netfilter.org "nftables" project")
+  * [Gentoo Nftables Examples](https://wiki.gentoo.org/wiki/Nftables/Examples "Gentoo Nftables Examples")
+  * [networking/nftables: add .tables property and disable ruleset flushing by default by mkg20001](https://github.com/NixOS/nixpkgs/pull/207758 "networking/nftables: add .tables property and disable ruleset flushing by default by mkg20001")
+  * [Example nftables config](https://paste.docs.lol/reader/OutburnsQuester "Example nftables config")
+  * [Olympia Mike on "verified only Flatpaks"](https://paste.docs.lol/reader/SuperheatsPigboats "Olympia Mike on "verified only Flatpaks"") — I'm curious your take on a recent update that happened in Linux Mint, and the possible knock on effect of it.
+  * [Incus is a next generation system container and virtual machine manager.](https://wiki.nixos.org/wiki/Incus "Incus is a next generation system container and virtual machine manager.")
+  * [Incus - NixOS Wiki](https://wiki.nixos.org/wiki/Incus "Incus - NixOS Wiki")
+  * [Moving from Proxmox to Incus](https://www.reddit.com/r/selfhosted/comments/1ay50ya/moving_from_proxmox_to_incus_lxc_webinterface/ "Moving from Proxmox to Incus")
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [Referral Code eXchange](https://rcx.bitcryptic.com "Referral Code eXchange")
+  * [auto-tab-discard](https://addons.mozilla.org/en-US/firefox/addon/auto-tab-discard/ "auto-tab-discard")
+  * [tab-session-manager](https://addons.mozilla.org/en-US/firefox/addon/tab-session-manager/ "tab-session-manager")
+  * [OneTab extension for Google Chrome and Firefox](https://www.one-tab.com/ "OneTab extension for Google Chrome and Firefox")
+  * [Tubular](https://github.com/polymorphicshade/Tubular "Tubular") — A fork of NewPipe that implements SponsorBlock and ReturnYouTubeDislike.
+
+
+
+## Tags
+
+[2fa](https://linuxunplugged.com/tags/2fa), [aegis](https://linuxunplugged.com/tags/aegis), [archcraft hyprland](https://linuxunplugged.com/tags/archcraft%20hyprland), [authy](https://linuxunplugged.com/tags/authy), [auto tab discard](https://linuxunplugged.com/tags/auto%20tab%20discard), [berlin meetup](https://linuxunplugged.com/tags/berlin%20meetup), [colo server](https://linuxunplugged.com/tags/colo%20server), [comcast fail](https://linuxunplugged.com/tags/comcast%20fail), [fido2](https://linuxunplugged.com/tags/fido2), [firehol](https://linuxunplugged.com/tags/firehol), [flathub](https://linuxunplugged.com/tags/flathub), [immich](https://linuxunplugged.com/tags/immich), [incus](https://linuxunplugged.com/tags/incus), [iptables](https://linuxunplugged.com/tags/iptables), [js8call](https://linuxunplugged.com/tags/js8call), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [keepassium](https://linuxunplugged.com/tags/keepassium), [keepassxc](https://linuxunplugged.com/tags/keepassxc), [linux mint](https://linuxunplugged.com/tags/linux%20mint), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [lxd](https://linuxunplugged.com/tags/lxd), [mesh network](https://linuxunplugged.com/tags/mesh%20network), [meshtastic](https://linuxunplugged.com/tags/meshtastic), [mixer vodka and vernors](https://linuxunplugged.com/tags/mixer%20vodka%20and%20vernors), [newpipe](https://linuxunplugged.com/tags/newpipe), [nftables](https://linuxunplugged.com/tags/nftables), [nixos](https://linuxunplugged.com/tags/nixos), [proxmox](https://linuxunplugged.com/tags/proxmox), [sat holiday](https://linuxunplugged.com/tags/sat%20holiday), [sponsorblock](https://linuxunplugged.com/tags/sponsorblock), [sunos](https://linuxunplugged.com/tags/sunos), [tailscale](https://linuxunplugged.com/tags/tailscale), [toronto meetup](https://linuxunplugged.com/tags/toronto%20meetup), [totp](https://linuxunplugged.com/tags/totp), [tree-style tabs](https://linuxunplugged.com/tags/tree-style%20tabs), [trusted interfaces](https://linuxunplugged.com/tags/trusted%20interfaces), [tubular](https://linuxunplugged.com/tags/tubular), [vps proxy](https://linuxunplugged.com/tags/vps%20proxy), [who exactly is wes payne?](https://linuxunplugged.com/tags/who%20exactly%20is%20wes%20payne%3F)

--- a/docs/linux-unplugged/2024/episode-577.md
+++ b/docs/linux-unplugged/2024/episode-577.md
@@ -1,0 +1,61 @@
+# LUP 577: Summer Kernel Corn Roast
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+cWtlIWNY?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-08-26
+* Duration: 80 mins 22 secs
+
+## About this episode
+
+Sixty vulnerabilities and exposures disclosed in one week sounds like a lot. We'll explain why it's just business as usual.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Toronto Meetup](https://www.meetup.com/jupiterbroadcasting/events/302700160/?eventOrigin=group_upcoming_events "Toronto Meetup") — Thursday, Aug 29, 2024
+  * [Berlin with Brent](https://www.meetup.com/jupiterbroadcasting/events/300421391/?eventOrigin=group_upcoming_events "Berlin with Brent") — September Meetup @ Nextcloud Conference, Saturday, Sep 14, 2024
+  * [Check out Alex’s “Building a Colo Server” video](https://youtu.be/zC_uKX2JSfc "Check out Alex’s “Building a Colo Server” video")
+  * [Microsoft’s latest security update has ruined dual-boot Windows and Linux PCs](https://www.theverge.com/2024/8/21/24225108/microsoft-security-update-windows-linux-dual-boot-errors "Microsoft’s latest security update has ruined dual-boot Windows and Linux PCs") — The cause: an update Microsoft issued as part of its monthly patch release. It was intended to close a 2-year-old vulnerability in GRUB, an open source boot loader used to start up many Linux devices.
+  * [What the f*** is an SBAT and why does everyone suddenly care](https://mjg59.dreamwidth.org/70348.html "What the f*** is an SBAT and why does everyone suddenly care") — This update was not supposed to apply to dual-boot systems, but did anyway.
+  * [SBAT Revocations: Boot Process - Ubuntu Community Hub](https://discourse.ubuntu.com/t/sbat-revocations-boot-process/34996 "SBAT Revocations: Boot Process - Ubuntu Community Hub")
+  * [“Something has gone seriously wrong,” dual-boot systems warn after Microsoft update](https://arstechnica.com/security/2024/08/a-patch-microsoft-spent-2-years-preparing-is-making-a-mess-for-some-linux-users/ "“Something has gone seriously wrong,” dual-boot systems warn after Microsoft update")
+  * [Ubuntu Will Be Skipping Non-Critical Linux Kernel Updates For September - Phoronix](https://www.phoronix.com/news/Ubuntu-Skipping-Kernel-SRU-Fix "Ubuntu Will Be Skipping Non-Critical Linux Kernel Updates For September - Phoronix")
+  * [SRU Mailing List Annoucement](https://lists.ubuntu.com/archives/kernel-team/2024-August/152944.htm "SRU Mailing List Annoucement")
+  * [Canonical Moves To Shipping Very Latest Upstream Kernel Code For Ubuntu Releases](https://www.phoronix.com/news/Ubuntu-Releases-Fresher-Kernels "Canonical Moves To Shipping Very Latest Upstream Kernel Code For Ubuntu Releases")
+  * [Kernel Version Selection for Ubuntu Releases - Kernel - Ubuntu Community Hub](https://discourse.ubuntu.com/t/kernel-version-selection-for-ubuntu-releases/47007 "Kernel Version Selection for Ubuntu Releases - Kernel - Ubuntu Community Hub")
+  * [Linus Torvalds Begins Expressing Regrets Merging Bcachefs](https://www.phoronix.com/news/Linus-Torvalds-Bcachefs-Regrets "Linus Torvalds Begins Expressing Regrets Merging Bcachefs") — The bcachefs patches have become these kinds of "lots of development during the release cycles rather than before it", to the point where I'm starting to regret merging bcachefs.
+  * [Re: [GIT PULL] bcachefs fixes for 6.11-rc5 - Linus Torvalds](https://lore.kernel.org/lkml/CAHk-=wj1Oo9-g-yuwWuHQZU8v=VAsBceWCRLhWxy7_-QnSa1Ng@mail.gmail.com/ "Re: \[GIT PULL\] bcachefs fixes for 6.11-rc5 - Linus Torvalds") — No one is being jerks here, Linus and I are just sitting in different places with different perspectives. He has a resonsibility as someone managing a huge project to enforce rules as he sees best, while I have a responsibility to support users with working code, and to do that to the best of my abilities.
+  * [LINUX Unplugged 545: 3,062 Days Later](https://linuxunplugged.com/545 "LINUX Unplugged 545: 3,062 Days Later") — Kent Overstreet, the creator of bcachefs, helps us understand where his new filesystem fits, what it's like to upstream a new filesystem, and how they've solved the RAID write hole.
+  * [Linux is a CNA](http://www.kroah.com/log/blog/2024/02/13/linux-is-a-cna/ "Linux is a CNA") — As was recently announced, the Linux kernel project has been accepted as a CNA as a CVE Numbering Authority (CNA) for vulnerabilities found in Linux.
+  * [The Linux security team issues 60 CVEs a week, but don't stress. Do this instead](https://www.zdnet.com/article/the-linux-security-team-issues-60-cves-a-week-but-dont-stress-do-this-instead/ "The Linux security team issues 60 CVEs a week, but don't stress. Do this instead")
+  * [What is a "good" Linux Kernel bug?](https://blog.isosceles.com/what-is-a-good-linux-kernel-bug/ "What is a "good" Linux Kernel bug?")
+  * [Keynote: Linux Kernel Security Demystified - Greg Kroah-Hartman - YouTube](https://www.youtube.com/watch?v=_yWhsynnxEg "Keynote: Linux Kernel Security Demystified - Greg Kroah-Hartman - YouTube")
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [added pihole nix module by Tdback · Pull Request #3 · JupiterBroadcasting/nixconfigs](https://github.com/JupiterBroadcasting/nixconfigs/pull/3 "added pihole nix module by Tdback · Pull Request #3 · JupiterBroadcasting/nixconfigs") — Recently, I wanted to start 'nixifying' some of my docker-compose setup. I've created a simple module for spinning up a podman container running pihole as a systemd service, so that way I can just stick it on any NixOS machine and easily make it my DNS server.
+  * [NetworkManager cli (nmci) wrapper to easily create a new network connection](https://github.com/bhh32/wifi "NetworkManager cli \(nmci\) wrapper to easily create a new network connection")
+  * [Distrohopper Wheel](https://halsschmerzen.github.io/distrohopper-wheel/ "Distrohopper Wheel")
+  * [No idea where to distrohop next? Let the ultimate distrohopper decide for you!](https://www.reddit.com/r/linux/s/5Wq04oYKFt "No idea where to distrohop next? Let the ultimate distrohopper decide for you!")
+  * [Proxmox Virtual Environment - NixOS Wiki](https://wiki.nixos.org/wiki/Proxmox_Virtual_Environment "Proxmox Virtual Environment - NixOS Wiki")
+  * [Pick: SaunaFS is a distributed file system](https://saunafs.com/ "Pick: SaunaFS is a distributed file system") — A robust distributed POSIX file system meticulously designed to revolutionize your storage solutions by offering unmatched efficiency, security, and redundancy. At its core, SaunaFS is a distributed file system primarily written in C++, inspired by the pioneering concepts introduced by Google File System.
+  * [Google File System - Wikipedia](https://en.wikipedia.org/wiki/Google_File_System "Google File System - Wikipedia")
+  * [saunafs/INSTALL.md](https://github.com/leil-io/saunafs/blob/main/INSTALL.md "saunafs/INSTALL.md")
+
+
+
+## Tags
+
+[2fa](https://linuxunplugged.com/tags/2fa), [alpine](https://linuxunplugged.com/tags/alpine), [ansible](https://linuxunplugged.com/tags/ansible), [bcachefs](https://linuxunplugged.com/tags/bcachefs), [berlin meetup](https://linuxunplugged.com/tags/berlin%20meetup), [canonical](https://linuxunplugged.com/tags/canonical), [cloudflare](https://linuxunplugged.com/tags/cloudflare), [cosmic alpha](https://linuxunplugged.com/tags/cosmic%20alpha), [cve](https://linuxunplugged.com/tags/cve), [cve-2022-2601](https://linuxunplugged.com/tags/cve-2022-2601), [dual-boot](https://linuxunplugged.com/tags/dual-boot), [efi](https://linuxunplugged.com/tags/efi), [gentoo](https://linuxunplugged.com/tags/gentoo), [greg kroah-hartman](https://linuxunplugged.com/tags/greg%20kroah-hartman), [grub](https://linuxunplugged.com/tags/grub), [hyprland](https://linuxunplugged.com/tags/hyprland), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kent overstreet](https://linuxunplugged.com/tags/kent%20overstreet), [linus torvalds](https://linuxunplugged.com/tags/linus%20torvalds), [linux 6.11](https://linuxunplugged.com/tags/linux%206.11), [linux kernel developer team](https://linuxunplugged.com/tags/linux%20kernel%20developer%20team), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [microsoft](https://linuxunplugged.com/tags/microsoft), [nix drinking game](https://linuxunplugged.com/tags/nix%20drinking%20game), [nixos](https://linuxunplugged.com/tags/nixos), [nixos feedback](https://linuxunplugged.com/tags/nixos%20feedback), [nixos image generator](https://linuxunplugged.com/tags/nixos%20image%20generator), [nixos stable or unstable](https://linuxunplugged.com/tags/nixos%20stable%20or%20unstable), [patch tuesday](https://linuxunplugged.com/tags/patch%20tuesday), [pihole](https://linuxunplugged.com/tags/pihole), [proxmox virtual environment](https://linuxunplugged.com/tags/proxmox%20virtual%20environment), [saunafs](https://linuxunplugged.com/tags/saunafs), [sbat](https://linuxunplugged.com/tags/sbat), [secure boot](https://linuxunplugged.com/tags/secure%20boot), [tailscale](https://linuxunplugged.com/tags/tailscale), [toronto meetup](https://linuxunplugged.com/tags/toronto%20meetup), [ublue cosmic](https://linuxunplugged.com/tags/ublue%20cosmic), [ubuntu](https://linuxunplugged.com/tags/ubuntu), [ubuntu 24.10](https://linuxunplugged.com/tags/ubuntu%2024.10), [ubuntu kernel](https://linuxunplugged.com/tags/ubuntu%20kernel)

--- a/docs/linux-unplugged/2024/episode-578.md
+++ b/docs/linux-unplugged/2024/episode-578.md
@@ -1,0 +1,65 @@
+# LUP 578: Young and the Rustless
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+3Pgij51g?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-09-01
+* Duration: 88 mins 37 secs
+
+## About this episode
+
+Rust meets Linux in a clash of coding cultures. Why some developers are resisting, and where things go from here.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Berlin with Brent: September Meetup @ Nextcloud Conference, Sat, Sep 14, 2024](https://www.meetup.com/jupiterbroadcasting/events/300421391/?eventOrigin=group_upcoming_events "Berlin with Brent: September Meetup @ Nextcloud Conference, Sat, Sep 14, 2024")
+  * [Berlin Buds on Matrix](https://matrix.to/#/%23berlin:jupiterbroadcasting.com "Berlin Buds on Matrix")
+  * [Linus Torvalds talks AI, Rust adoption, and why the Linux kernel is 'the only thing that matters'](https://www.zdnet.com/article/linus-torvalds-talks-ai-rust-adoption-and-why-the-linux-kernel-is-the-only-thing-that-matters/ "Linus Torvalds talks AI, Rust adoption, and why the Linux kernel is 'the only thing that matters'")
+  * [KubeCon + CloudNativeCon + Open Source Summit + AI_Dev China 2024](https://kccncossaidevchn2024.sched.com/event/1eZrx/keynote-linus-torvalds-creator-of-linux-git-in-conversation-with-dirk-hohndel-head-of-the-open-source-program-office-verizon-mo-3hxi-linuxregitzha-linus-torvaldsverizontu-ju-dirk-hohndelzha-tuo "KubeCon + CloudNativeCon + Open Source Summit + AI_Dev China 2024")
+  * [Rust for filesystems](https://lwn.net/Articles/978738/ "Rust for filesystems") — At the 2024 Linux Storage, Filesystem, Memory Management, and BPF Summit, Wedson Almeida Filho and Kent Overstreet led a combined storage and filesystem session on using Rust for Linux filesystems.
+  * [Filesystem in Rust - Kent Overstreet and Wedson Almeida Filho](https://www.youtube.com/watch?v=WiPp9YEBV0Q "Filesystem in Rust - Kent Overstreet and Wedson Almeida Filho")
+  * [Asahi Lina: "I think people really don't appreciate just how incomplete Linux kernel API docs are, and how Rust solves part of the problem."](https://vt.social/@lina/113056457969145576 "Asahi Lina: "I think people really don't appreciate just how incomplete Linux kernel API docs are, and how Rust solves part of the problem."")
+  * [One Of The Rust Linux Kernel Maintainers Steps Down - Cites "Nontechnical Nonsense"](https://www.phoronix.com/news/Rust-Linux-Maintainer-Step-Down "One Of The Rust Linux Kernel Maintainers Steps Down - Cites "Nontechnical Nonsense"") — One of the several Rust for Linux kernel maintainers has decided to step away from the project. The move is being driven at least in part due to having to deal with increased "nontechnical nonsense" raised around Rust programming language use within the Linux kernel.
+  * [[PATCH 0/1] Retiring from the Rust for Linux project - Wedson Almeida Filho](https://lore.kernel.org/lkml/20240828211117.9422-1-wedsonaf@gmail.com/ "\[PATCH 0/1\] Retiring from the Rust for Linux project - Wedson Almeida Filho")
+  * [On Rust, Linux, developers, maintainers](https://airlied.blogspot.com/2024/08/on-rust-linux-developers-maintainers.html "On Rust, Linux, developers, maintainers") — There's been a couple of mentions of Rust4Linux in the past week or two, one from Linus on the speed of engagement and one about Wedson departing the project due to non-technical concerns. This got me thinking about project phases and developer types.
+  * [The revival of the Linux C++ discussion](https://www.phoronix.com/news/CPP-Linux-Kernel-2024-Discuss "The revival of the Linux C++ discussion")
+  * [Membership Summer Discount](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer "Membership Summer Discount") — Take $1 a month of your membership for a lifetime!
+  * [Thank you Core Contributors](https://h.docs.lol/P2dCEHiLQ-myWSfutiqD7Q# "Thank you Core Contributors")
+  * [BrewHouse by the Lake – Amsterdam Brewery Shop](https://amsterdambeer.com/pages/brewhouse-by-the-lake "BrewHouse by the Lake – Amsterdam Brewery Shop")
+  * [BITCOIN WELL](https://bitcoinwell.com/ "BITCOIN WELL") — The fastest and safest way to buy bitcoin in Canada
+  * [The new JB server - KTZ systems](https://www.youtube.com/watch?v=6CZad9Qjfxo "The new JB server - KTZ systems") — Join Alex, Chris, and Brent as we fly to Toronto to deploy our shiny new colo server in Canada. We'll be deploying the 45homelab HL15 server.
+  * [Projectivy Launcher](https://play.google.com/store/apps/details?id=com.spocky.projengmenu&hl=en_US "Projectivy Launcher")
+  * [Aerial Views Screensaver](https://play.google.com/store/apps/details?id=com.neilturner.aerialviews&hl=en_US "Aerial Views Screensaver")
+  * [OpenEBS](https://github.com/openebs/openebs "OpenEBS") — OpenEBS is a modern Block-Mode storage platform, a Hyper-Converged software Storage System and virtual NVMe-oF SAN (vSAN) Fabric that is natively integrates into the core of Kubernetes.
+  * [oppy1984's Satoshi Survey](https://oppy1984.com/Satoshi-Survey "oppy1984's Satoshi Survey")
+  * [Coder Radio 582](https://coder.show/582 "Coder Radio 582")
+  * [Keybase Filesystem Storage Limits](https://book.keybase.io/docs/files#storage "Keybase Filesystem Storage Limits")
+  * [I Don't Care for Gnome](https://woltman.com/gnome-bad/ "I Don't Care for Gnome")
+  * [DAVx5](https://www.davx5.com/ "DAVx5") — DAVx⁵ DAVx⁵ – CalDAV / CardDAV / WebDAV for Android
+  * [Flock 2024 Universal Blue: Building the Future using Fedora Atomic](https://www.youtube.com/watch?v=uMkePEflqpk "Flock 2024 Universal Blue: Building the Future using Fedora Atomic")
+  * [Pick: Shotcut - New Version 24.08](https://www.shotcut.org/blog/new-release-240829/ "Pick: Shotcut - New Version 24.08")
+  * [Install Shotcut on Flathub](https://flathub.org/apps/org.shotcut.Shotcut "Install Shotcut on Flathub") — Shotcut supports many video, audio, and image formats via FFmpeg and screen, webcam, and audio capture. It uses a time-line for non-linear video editing of multiple tracks that may be composed of various file formats. Scrubbing and transport control are assisted by OpenGL GPU-based processing and a number of video and audio filters are available.
+  * [Bonus Pick: Butler](https://flathub.org/apps/com.cassidyjames.butler "Bonus Pick: Butler") — Access your Home Assistant dashboard from a native companion UI, integrating better with your OS.
+  * [Butler on GitHub](https://github.com/cassidyjames/butler "Butler on GitHub")
+  * [Rust for Linux revisited](https://drewdevault.com/2024/08/30/2024-08-30-Rust-in-Linux-revisited.html "Rust for Linux revisited")
+  * [Redox OS](https://www.redox-os.org/ "Redox OS") — Redox is a Unix-like general-purpose microkernel-based operating system written in Rust, aiming to bring the innovations of Rust to a modern microkernel, a full set of programs and be a complete alternative to Linux and BSD.
+
+
+
+## Tags
+
+[2fa](https://linuxunplugged.com/tags/2fa), [american maple syrup](https://linuxunplugged.com/tags/american%20maple%20syrup), [appletv no more](https://linuxunplugged.com/tags/appletv%20no%20more), [bazzite](https://linuxunplugged.com/tags/bazzite), [berlin meetup](https://linuxunplugged.com/tags/berlin%20meetup), [beverly by coke](https://linuxunplugged.com/tags/beverly%20by%20coke), [bitcoin well](https://linuxunplugged.com/tags/bitcoin%20well), [buy bitcoin in canada](https://linuxunplugged.com/tags/buy%20bitcoin%20in%20canada), [c](https://linuxunplugged.com/tags/c), [c++](https://linuxunplugged.com/tags/c++), [chrislas since middle school](https://linuxunplugged.com/tags/chrislas%20since%20middle%20school), [davx5](https://linuxunplugged.com/tags/davx5), [dc stephen](https://linuxunplugged.com/tags/dc%20stephen), [dirk hohndel](https://linuxunplugged.com/tags/dirk%20hohndel), [fido2 keys](https://linuxunplugged.com/tags/fido2%20keys), [hand-smacking os](https://linuxunplugged.com/tags/hand-smacking%20os), [hawn dale](https://linuxunplugged.com/tags/hawn%20dale), [ipfs](https://linuxunplugged.com/tags/ipfs), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [keybase.io](https://linuxunplugged.com/tags/keybase.io), [kiro](https://linuxunplugged.com/tags/kiro), [linus torvalds](https://linuxunplugged.com/tags/linus%20torvalds), [linux kernel](https://linuxunplugged.com/tags/linux%20kernel), [linux kernel api](https://linuxunplugged.com/tags/linux%20kernel%20api), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux strorage filesystem summit](https://linuxunplugged.com/tags/linux%20strorage%20filesystem%20summit), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [longhorn](https://linuxunplugged.com/tags/longhorn), [maple sats](https://linuxunplugged.com/tags/maple%20sats), [nixos](https://linuxunplugged.com/tags/nixos), [nontechnical nonsense](https://linuxunplugged.com/tags/nontechnical%20nonsense), [open source summit](https://linuxunplugged.com/tags/open%20source%20summit), [pantheon](https://linuxunplugged.com/tags/pantheon), [rust](https://linuxunplugged.com/tags/rust), [rust4linux](https://linuxunplugged.com/tags/rust4linux), [seaweedfs](https://linuxunplugged.com/tags/seaweedfs), [soc 2](https://linuxunplugged.com/tags/soc%202), [toronto meetup](https://linuxunplugged.com/tags/toronto%20meetup), [totp](https://linuxunplugged.com/tags/totp), [vaultwarden](https://linuxunplugged.com/tags/vaultwarden), [wedson almeida filho](https://linuxunplugged.com/tags/wedson%20almeida%20filho)

--- a/docs/linux-unplugged/2024/episode-579.md
+++ b/docs/linux-unplugged/2024/episode-579.md
@@ -1,0 +1,34 @@
+# LUP 579: Lost & Found
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+UXqLw__D?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-09-08
+* Duration: 57 mins 45 secs
+
+## About this episode
+
+Secret moments from the show you've never heard before. We kick off with some hardware hurdles, then dive into the news and share a few surprising stories.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+
+
+
+## Tags
+
+[firefox](https://linuxunplugged.com/tags/firefox), [floppy disk](https://linuxunplugged.com/tags/floppy%20disk), [free deck](https://linuxunplugged.com/tags/free%20deck), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged)

--- a/docs/linux-unplugged/2024/episode-580.md
+++ b/docs/linux-unplugged/2024/episode-580.md
@@ -1,0 +1,50 @@
+# LUP 580: Brent's Boogie Bus Broadcast Bash
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+Q5GdvnY1?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-09-15
+* Duration: 71 mins 41 secs
+
+## About this episode
+
+The things we like in the new Nextcloud release, and we attempt to upgrade our production server live—from a big blue bus.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+* [Brent Gervais](https://linuxunplugged.com/hosts/brent)
+
+## Sponsored by
+
+  * [Core Contributor Membership](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer): [Take $1 a month of your membership for a lifetime!](https://jupitersignal.memberful.com/checkout?plan=52946&coupon=summer)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [OpenSats Grants Long-Term Support for WireGuard Creator Jason Donenfeld](https://www.nobsbitcoin.com/opensats-lts-jason-donenfeld/ "OpenSats Grants Long-Term Support for WireGuard Creator Jason Donenfeld")
+  * [OpenSats Lightning Node](https://amboss.space/node/037c862ec724bc85462aaeb804dd0941cd77dc4521cabd05edf3d0f23ed6b01f09 "OpenSats Lightning Node")
+  * [Nextcloud Hub 9](https://nextcloud.com/blog/nextcloud-hub9/ "Nextcloud Hub 9")
+  * [Introducing Nextcloud Hub 9 - the world's leading open source collaboration platform! - YouTube](https://www.youtube.com/watch?v=EnT_OVfE4nw "Introducing Nextcloud Hub 9 - the world's leading open source collaboration platform! - YouTube")
+  * [Day 1: Nextcloud Community Conference 2024 - YouTube](https://www.youtube.com/watch?v=xdKAOOxQwSI "Day 1: Nextcloud Community Conference 2024 - YouTube")
+  * [Day 2: Nextcloud Community Conference 2024 - YouTube](https://www.youtube.com/watch?v=acQK7Yx8mBI "Day 2: Nextcloud Community Conference 2024 - YouTube")
+  * [Nextcloud Community Conference 2024](https://nextcloud.com/conference-2024/ "Nextcloud Community Conference 2024")
+  * [Mailvelope](https://mailvelope.com/ "Mailvelope") — Mailvelope is a browser add-on that you can use in Chrome, Edge and Firefox to securely encrypt your emails with PGP using webmail providers
+  * [Nextcloud Server Releases](https://download.nextcloud.com/server/releases/ "Nextcloud Server Releases")
+  * [nextcloud/docker: ⛴ Docker image of Nextcloud](https://github.com/nextcloud/docker "nextcloud/docker: ⛴ Docker image of Nextcloud")
+  * [Bug: Unable to update background execution mode: conflict between new type (mixed) and old type (string)](https://github.com/nextcloud/server/issues/45083#issuecomment-2192924684 "Bug: Unable to update background execution mode: conflict between new type \(mixed\) and old type \(string\)")
+  * [VLESS](https://www.v2fly.org/config/protocols/vless.html "VLESS")
+  * [hacompanion: Daemon that sends local hardware information to Home Assistant.](https://github.com/tobias-kuendig/hacompanion "hacompanion: Daemon that sends local hardware information to Home Assistant.")
+  * [LNXlink: 🖥 Effortlessly manage your Linux machine using MQTT.](https://github.com/bkbilly/lnxlink "LNXlink:  🖥 Effortlessly manage your Linux machine using MQTT.")
+  * [Waycheck](https://flathub.org/apps/dev.serebit.Waycheck "Waycheck") — Waycheck is a simple graphical application that connects to your Wayland compositor and displays the list of Wayland protocols that it supports, along with the list of protocols that it doesn't.
+  * [Supersonic](https://flathub.org/apps/io.github.dweymouth.supersonic "Supersonic") — A lightweight cross-platform desktop client for Subsonic and Jellyfin music servers.
+
+
+
+## Tags
+
+[amd](https://linuxunplugged.com/tags/amd), [apple vision pro](https://linuxunplugged.com/tags/apple%20vision%20pro), [autoflow](https://linuxunplugged.com/tags/autoflow), [berlin](https://linuxunplugged.com/tags/berlin), [boost](https://linuxunplugged.com/tags/boost), [cosmic](https://linuxunplugged.com/tags/cosmic), [encryption](https://linuxunplugged.com/tags/encryption), [executive director](https://linuxunplugged.com/tags/executive%20director), [federation](https://linuxunplugged.com/tags/federation), [file request](https://linuxunplugged.com/tags/file%20request), [framework laptop](https://linuxunplugged.com/tags/framework%20laptop), [gnome](https://linuxunplugged.com/tags/gnome), [homeassistant](https://linuxunplugged.com/tags/homeassistant), [hub 9](https://linuxunplugged.com/tags/hub%209), [intel](https://linuxunplugged.com/tags/intel), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kde](https://linuxunplugged.com/tags/kde), [linux 6.11](https://linuxunplugged.com/tags/linux%206.11), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [mailvelope](https://linuxunplugged.com/tags/mailvelope), [membership discount](https://linuxunplugged.com/tags/membership%20discount), [nextcloud](https://linuxunplugged.com/tags/nextcloud), [nix](https://linuxunplugged.com/tags/nix), [opensats](https://linuxunplugged.com/tags/opensats), [supersonic](https://linuxunplugged.com/tags/supersonic), [waycheck](https://linuxunplugged.com/tags/waycheck), [windmill](https://linuxunplugged.com/tags/windmill), [wireguard](https://linuxunplugged.com/tags/wireguard)

--- a/docs/linux-unplugged/2024/episode-581.md
+++ b/docs/linux-unplugged/2024/episode-581.md
@@ -1,0 +1,51 @@
+# LUP 581: The Linux Escape Hatch
+
+<iframe src="https://player.fireside.fm/v2/RUkczH-V+YMkstzT7?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2024-09-22
+* Duration: 67 mins 38 secs
+
+## About this episode
+
+What if we had to abandon ship and stop using Desktop Linux? We've come up with a master plan, and put it to the test.
+
+## Your hosts
+* [Chris Fisher](https://linuxunplugged.com/hosts/chrislas)
+* [Wes Payne](https://linuxunplugged.com/hosts/wes)
+
+## Sponsored by
+
+  * [Jupiter Party Annual Membership](https://jupitersignal.memberful.com/checkout?plan=117630r): [Put your support on automatic with our annual plan, and get one month of membership for free!](https://jupitersignal.memberful.com/checkout?plan=117630r)
+  * [Tailscale](http://tailscale.com/linuxunplugged): [Tailscale is a programmable networking software that is private and secure by default - get it free on up to 100 devices!](http://tailscale.com/linuxunplugged)
+  * [1Password Extended Access Management](https://1password.com/unplugged): [1Password Extended Access Management is a device trust solution for companies with Okta, and they ensure that if a device isn't trusted and secure, it can't log into your cloud apps.](https://1password.com/unplugged)
+
+
+
+## Episode links
+
+  * [💥 Gets Sats Quick and Easy with Strike](https://strike.me/ "💥 Gets Sats Quick and Easy with Strike")
+  * [📻 LINUX Unplugged on Fountain.FM](https://www.fountain.fm/show/dWiuBeqpDSM86AwXRXov "📻 LINUX Unplugged  on Fountain.FM")
+  * [Meshtastic Linux-Native Application](https://meshtastic.org/docs/software/linux-native/ "Meshtastic Linux-Native Application")
+  * [MeshMap](https://meshmap.net/ "MeshMap") — Meshtastic Node Map
+  * [LINUX Unplugged 269](https://linuxunplugged.com/269 "LINUX Unplugged 269") — What if desktop computing went a very different direction in the late 90s? Deeply multithreaded from the start, fast, intuitive, and extremely stable. This is the world of Haiku, and we go for a visit.
+  * [The Dawn of Haiku OS](https://spectrum.ieee.org/the-dawn-of-haiku-os "The Dawn of Haiku OS") — Haiku, unlike its more established competitors, is exceedingly good at tackling one of the toughest challenges of modern computing: multicore microprocessors. Let's take a look at why that is, how Haiku came to be, and whether the operating system running on your computer really performs as well as it should.
+  * [Haiku Project History](https://www.haiku-os.org/about/history "Haiku Project History")
+  * [Haiku R1/beta5 Release Notes](https://www.haiku-os.org/get-haiku/r1beta5/release-notes/ "Haiku R1/beta5 Release Notes") — The fifth beta for Haiku R1 over a year and a half of hard work to improve Haiku’s hardware support and its overall stability, and to make lots more software ports available for use.
+  * [docker-qemu-haiku](https://github.com/hectorm/docker-qemu-haiku "docker-qemu-haiku") — A Docker image for the Haiku operating system.
+  * [golang-haiku/go](https://github.com/golang-haiku/go "golang-haiku/go") — The Haiku port of the Go programming language for upstream support. Changes are made in 'golang-1.11-haiku' or 'golang-haiku-master'.
+  * [Using the remote app server | Haiku Project](https://www.haiku-os.org/node/6007 "Using the remote app server | Haiku Project")
+  * [JB Haiku Server](http://haiku.jupiterbroadcasting.com/ "JB Haiku Server")
+  * [Lighttpd](https://www.lighttpd.net/ "Lighttpd")
+  * [DHH Talks Apple, Linux, and Running Servers](https://episodes.fm/1651741524/episode/N2JlMzM4ZGQtMGFkNS00NWVjLWE5MjktZTRkM2EzYzA3YTJj "DHH Talks Apple, Linux, and Running Servers")
+  * [Annual Membership](https://jupitersignal.memberful.com/checkout?plan=117630 "Annual Membership") — Put your support on automatic with our annual plan, and get one month of membership for free!
+  * [dadjoke-cli](https://github.com/Anupya/dadjoke-cli "dadjoke-cli")
+  * [colmena](https://github.com/zhaofengli/colmena "colmena")
+  * [spectorus' NixOS Config](https://github.com/mikeodr/nixos-config/ "spectorus' NixOS Config")
+  * [Pick: rustpad](https://github.com/ekzhang/rustpad?tab=readme-ov-file "Pick: rustpad") — Efficient and minimal collaborative code editor, self-hosted, no database required
+  * [Is the Nostr moment officially here?](https://stacker.news/items/696199 "Is the Nostr moment officially here?")
+
+
+
+## Tags
+
+[apple](https://linuxunplugged.com/tags/apple), [community engagement](https://linuxunplugged.com/tags/community%20engagement), [developer focus](https://linuxunplugged.com/tags/developer%20focus), [dhh](https://linuxunplugged.com/tags/dhh), [haiku os](https://linuxunplugged.com/tags/haiku%20os), [jupiter broadcasting](https://linuxunplugged.com/tags/jupiter%20broadcasting), [kernel development](https://linuxunplugged.com/tags/kernel%20development), [linux alternatives](https://linuxunplugged.com/tags/linux%20alternatives), [linux evangelism](https://linuxunplugged.com/tags/linux%20evangelism), [linux podcast](https://linuxunplugged.com/tags/linux%20podcast), [linux unplugged](https://linuxunplugged.com/tags/linux%20unplugged), [lora radios](https://linuxunplugged.com/tags/lora%20radios), [mesh networks](https://linuxunplugged.com/tags/mesh%20networks), [meshtastic](https://linuxunplugged.com/tags/meshtastic), [nix](https://linuxunplugged.com/tags/nix), [off-grid communication](https://linuxunplugged.com/tags/off-grid%20communication), [omakub](https://linuxunplugged.com/tags/omakub), [open-source](https://linuxunplugged.com/tags/open-source), [ruby on rails](https://linuxunplugged.com/tags/ruby%20on%20rails), [rust](https://linuxunplugged.com/tags/rust), [software ports](https://linuxunplugged.com/tags/software%20ports), [stability](https://linuxunplugged.com/tags/stability), [system management](https://linuxunplugged.com/tags/system%20management), [web development](https://linuxunplugged.com/tags/web%20development)

--- a/docs/office-hours/2023/episode-p01.md
+++ b/docs/office-hours/2023/episode-p01.md
@@ -1,0 +1,33 @@
+# OFH p01: Bounty Reached
+
+<iframe src="https://player.fireside.fm/v2/MkcqFyfv+tWl7xCsa?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2023-08-04
+* Duration: {hours} hours {minutes} mins {seconds} secs
+
+## About this episode
+
+A quick Pocket Office from "the field" on the new tech inbound to Office Hours and a big update on our bounty for episode 34!
+
+## Your hosts
+* [Chris Fisher](https://www.officehours.hair//hosts/chrislas)
+
+## Sponsored by
+
+  * [Send us a Boost w/a new Podcast App](http://newpodcastapps.com/): [Send a boost into the show, try out a new app, and help keep podcasting independent. ](http://newpodcastapps.com/)
+
+
+
+## Episode links
+
+  * [Sovereign Feeds](https://sovereignfeeds.com/ "Sovereign Feeds")
+  * [IPFS Podcasting](https://ipfspodcasting.net "IPFS Podcasting")
+  * [IPFS Podcasting | Umbrel App Store](https://apps.umbrel.com/app/ipfs-podcasting "IPFS Podcasting | Umbrel App Store") — Turn your Umbrel into an IPFS node for self-hosting, crowd-hosting, and archiving of your favorite podcasts to the IPFS network.
+  * [IPFS Podcast Prefix | IPFS Podcasting](https://ipfspodcasting.net/Help/Prefix "IPFS Podcast Prefix | IPFS Podcasting") — You can configure your feed to load episodes from IPFS using a podcast prefix in your enclosure url.
+  * [Run a Node | IPFS Podcasting](https://ipfspodcasting.net/RunNode "Run a Node | IPFS Podcasting") — If you have a mini-PC (i.e. Raspberry Pi), an old computer, or an advanced server, you can run a node to host podcast episodes. 
+
+
+
+## Tags
+
+[bounty reached](https://www.officehours.hair//tags/bounty%20reached), [chris fisher](https://www.officehours.hair//tags/chris%20fisher), [chrislas](https://www.officehours.hair//tags/chrislas), [cloud chapters](https://www.officehours.hair//tags/cloud%20chapters), [computers](https://www.officehours.hair//tags/computers), [corn fields](https://www.officehours.hair//tags/corn%20fields), [digital](https://www.officehours.hair//tags/digital), [effort](https://www.officehours.hair//tags/effort), [entire feed hosting](https://www.officehours.hair//tags/entire%20feed%20hosting), [episode 34](https://www.officehours.hair//tags/episode%2034), [episode hosting on ipfs](https://www.officehours.hair//tags/episode%20hosting%20on%20ipfs), [episode removal from ipfs](https://www.officehours.hair//tags/episode%20removal%20from%20ipfs), [feed favoriting](https://www.officehours.hair//tags/feed%20favoriting), [feed favoriting by nodes](https://www.officehours.hair//tags/feed%20favoriting%20by%20nodes), [feed submission](https://www.officehours.hair//tags/feed%20submission), [fireside](https://www.officehours.hair//tags/fireside), [first year](https://www.officehours.hair//tags/first%20year), [garden](https://www.officehours.hair//tags/garden), [gardening](https://www.officehours.hair//tags/gardening), [growing corn field](https://www.officehours.hair//tags/growing%20corn%20field), [hosting platform](https://www.officehours.hair//tags/hosting%20platform), [humbling experience](https://www.officehours.hair//tags/humbling%20experience), [ipfs enabled feed](https://www.officehours.hair//tags/ipfs%20enabled%20feed), [ipfs gateway](https://www.officehours.hair//tags/ipfs%20gateway), [ipfs network](https://www.officehours.hair//tags/ipfs%20network), [ipfs podcast prefix](https://www.officehours.hair//tags/ipfs%20podcast%20prefix), [ipfs podcasting](https://www.officehours.hair//tags/ipfs%20podcasting), [ipfs stats](https://www.officehours.hair//tags/ipfs%20stats), [jupiter broadcasting](https://www.officehours.hair//tags/jupiter%20broadcasting), [learning](https://www.officehours.hair//tags/learning), [mistakes](https://www.officehours.hair//tags/mistakes), [office hours](https://www.officehours.hair//tags/office%20hours), [office hours bounty](https://www.officehours.hair//tags/office%20hours%20bounty), [pacific northwest](https://www.officehours.hair//tags/pacific%20northwest), [pocket office 1](https://www.officehours.hair//tags/pocket%20office%201), [podcast clients](https://www.officehours.hair//tags/podcast%20clients), [podcasting 2.0 features](https://www.officehours.hair//tags/podcasting%202.0%20features), [re-tooling publishing backend](https://www.officehours.hair//tags/re-tooling%20publishing%20backend), [tech inbound](https://www.officehours.hair//tags/tech%20inbound), [transcripts](https://www.officehours.hair//tags/transcripts), [v4v to ipfs podcasting](https://www.officehours.hair//tags/v4v%20to%20ipfs%20podcasting), [volunteer bandwidth](https://www.officehours.hair//tags/volunteer%20bandwidth), [volunteer ipfs nodes](https://www.officehours.hair//tags/volunteer%20ipfs%20nodes), [volunteer storage](https://www.officehours.hair//tags/volunteer%20storage)

--- a/docs/office-hours/2023/episode-p02.md
+++ b/docs/office-hours/2023/episode-p02.md
@@ -1,0 +1,31 @@
+# OFH p02: We Broke Things Again
+
+<iframe src="https://player.fireside.fm/v2/MkcqFyfv+_ZTS19rj?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2023-08-16
+* Duration: {hours} hours {minutes} mins {seconds} secs
+
+## About this episode
+
+Chris and Brent are running with scissors and breaking things again.
+
+## Your hosts
+* [Chris Fisher](https://www.officehours.hair//hosts/chrislas)
+* [Brent Gervais](https://www.officehours.hair//hosts/brentgervais)
+
+## Sponsored by
+
+  * [Join the Party! The Jupiter Membership Party](https://www.jupiter.party/): [Join the party and get exclusive content. ](https://www.jupiter.party/)
+  * [Send us a Boost w/a new Podcast App](http://newpodcastapps.com/): [Send a boost into the show, try out a new app, and help keep podcasting independent. ](http://newpodcastapps.com/)
+
+
+
+## Episode links
+
+None
+
+
+
+## Tags
+
+[ai chapters](https://www.officehours.hair//tags/ai%20chapters), [chancem's potential fix](https://www.officehours.hair//tags/chancem's%20potential%20fix), [chrislas](https://www.officehours.hair//tags/chrislas), [ipfs downloads](https://www.officehours.hair//tags/ipfs%20downloads), [ipfs node crashing](https://www.officehours.hair//tags/ipfs%20node%20crashing), [ipfs switch](https://www.officehours.hair//tags/ipfs%20switch), [jupiter broadcasting](https://www.officehours.hair//tags/jupiter%20broadcasting), [new rss feed redirect issue](https://www.officehours.hair//tags/new%20rss%20feed%20redirect%20issue), [office hours](https://www.officehours.hair//tags/office%20hours), [office hours 2.0](https://www.officehours.hair//tags/office%20hours%202.0), [rss feed redirect challenge](https://www.officehours.hair//tags/rss%20feed%20redirect%20challenge), [v4v](https://www.officehours.hair//tags/v4v), [value 4 value](https://www.officehours.hair//tags/value%204%20value), [value for value](https://www.officehours.hair//tags/value%20for%20value), [whisper-powered transcripts](https://www.officehours.hair//tags/whisper-powered%20transcripts)

--- a/docs/office-hours/2023/episode-p03.md
+++ b/docs/office-hours/2023/episode-p03.md
@@ -1,0 +1,35 @@
+# OFH p03: We'll do it LIVE!
+
+<iframe src="https://player.fireside.fm/v2/MkcqFyfv+VEHoIu_r?theme=dark" width="740" height="200" frameborder="0" scrolling="no"></iframe>
+
+* Air Date: 2023-09-13
+* Duration: {hours} hours {minutes} mins {seconds} secs
+
+## About this episode
+
+We're testing a new Podcasting 2.0 feature and need your ears!
+
+## Your hosts
+* [Chris Fisher](https://www.officehours.hair//hosts/chrislas)
+
+## Sponsored by
+
+  * [Send us a Boost w/a new Podcast App](http://newpodcastapps.com/): [Send a boost into the show, try out a new app, and help keep podcasting independent. ](http://newpodcastapps.com/)
+  * [Join the Party! The Jupiter Membership Party](https://www.jupiter.party/): [Join the party and get exclusive content. ](https://www.jupiter.party/)
+
+
+
+## Episode links
+
+  * [⚡ Alby: Your Boost companion for the web](https://getalby.com/ "⚡ Alby: Your Boost companion for the web")
+  * [🎉 Office Hours on the Podcastindex.org](https://podcastindex.org/podcast/5341434 "🎉 Office Hours on the Podcastindex.org") — Boost from the Web. Once you have Alby topped off, you can Boost from our page on the Podcast Index.
+  * [Podverse: Jupiter Station](https://podverse.fm/podcast/Z3WCCOxYBB "Podverse: Jupiter Station")
+  * [Fountain: Jupiter Station](https://fountain.fm/show/o4cajw7EtkLUiVktdEHU "Fountain: Jupiter Station")
+  * [Podfriend: Jupiter Station](https://www.podfriend.com/podcast/jupiter-station/ "Podfriend: Jupiter Station")
+  * [jblive.fm Direct Link](http://jblive.fm/ "jblive.fm Direct Link")
+
+
+
+## Tags
+
+[chrislas](https://www.officehours.hair//tags/chrislas), [classic episodes](https://www.officehours.hair//tags/classic%20episodes), [improvement proposal](https://www.officehours.hair//tags/improvement%20proposal), [jupiter broadcasting](https://www.officehours.hair//tags/jupiter%20broadcasting), [jupiter station](https://www.officehours.hair//tags/jupiter%20station), [lit](https://www.officehours.hair//tags/lit), [live feed](https://www.officehours.hair//tags/live%20feed), [live status](https://www.officehours.hair//tags/live%20status), [metadata](https://www.officehours.hair//tags/metadata), [office hours](https://www.officehours.hair//tags/office%20hours), [podcasting 2.0](https://www.officehours.hair//tags/podcasting%202.0), [push notification](https://www.officehours.hair//tags/push%20notification), [value block](https://www.officehours.hair//tags/value%20block), [weekly live streams](https://www.officehours.hair//tags/weekly%20live%20streams)


### PR DESCRIPTION
This PR adds the currently missing LINUX Unplugged episodes, as well as a few other episodes that failed to scrape previously due to not having a regular integer episode number. This data was scraped with the changes from #31. 